### PR TITLE
Add support for iterating set bits in flags.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,9 @@ travis-ci = { repository = "rust-lang-nursery/bitflags" }
 [features]
 default = ["example_generated"]
 example_generated = []
+iterator = ["num-traits"]
+
+[dependencies.num-traits]
+version = "0.2"
+default-features = false
+optional = true

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,0 +1,67 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use num_traits::int::PrimInt;
+use num_traits::ops::wrapping::WrappingSub;
+use num_traits::{One, Zero};
+
+pub trait BitFlags {
+    type Bits;
+    type Flags;
+
+    fn as_bits(&self) -> Self::Bits;
+    fn from_bits(Self::Bits) -> Self::Flags;
+}
+
+/// An iterator over each flag set in a `BitFlags` struct.
+///
+/// This `struct` is create by the [`iter`] function.
+#[derive(Debug)]
+pub struct BitFlagsIter<B>
+where
+    B: BitFlags,
+{
+    flags: B,
+    bit: B::Bits,
+}
+
+impl<B> BitFlagsIter<B>
+where
+    B: BitFlags,
+    B::Bits: PrimInt,
+{
+    pub fn new(flags: B) -> Self {
+        BitFlagsIter {
+            flags,
+            bit: B::Bits::one(),
+        }
+    }
+}
+
+impl<B> Iterator for BitFlagsIter<B>
+where
+    B: BitFlags,
+    B::Bits: PrimInt + WrappingSub,
+{
+    type Item = B::Flags;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let flags = self.flags.as_bits();
+        let t = self.bit.wrapping_sub(&B::Bits::one());
+        while (flags & !t) != B::Bits::zero() {
+            let test_bit = self.bit;
+            self.bit = self.bit.unsigned_shl(1);
+            if (flags & test_bit) != B::Bits::zero() {
+                return Some(B::from_bits(test_bit));
+            }
+        }
+        None
+    }
+}


### PR DESCRIPTION
This implements #28.

This is gated by feature = "iterator" because it adds a new trait and struct, as well as using `num-traits` crate to aid the generic implementation of `struct BitFlagsIter`.

I'm looking for feedback on the implementation of `BitFlagsIter`. I tried to implement this with out introducting the `BitFlags` trait, but I couldn't work out how to create a `bitflags!` struct with out the trait to enable conversion from raw bits to wrapped type.

I also tried implementing `fn next()` with out the help from `num-traits` but I had trouble getting `Wrapping` for `Sub` to resolve.

This needs documentation before it can land. 