### PR TITLE
Update url refs to bitflags for new org

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 keywords = ["bit", "bitmask", "bitflags", "flags"]
 readme = "README.md"
-repository = "https://github.com/rust-lang-nursery/bitflags"
-homepage = "https://github.com/rust-lang-nursery/bitflags"
+repository = "https://github.com/bitflags/bitflags"
+homepage = "https://github.com/bitflags/bitflags"
 documentation = "https://docs.rs/bitflags"
 categories = ["no-std"]
 description = """
@@ -18,7 +18,7 @@ A macro to generate structures which behave like bitflags.
 """
 
 [badges]
-travis-ci = { repository = "rust-lang-nursery/bitflags" }
+travis-ci = { repository = "bitflags/bitflags" }
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ bitflags
 
 A Rust macro to generate structures which behave like a set of bitflags
 
-[![Build Status](https://travis-ci.org/rust-lang-nursery/bitflags.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/bitflags)
+[![Build Status](https://travis-ci.org/bitflags/bitflags.svg?branch=master)](https://travis-ci.org/bitflags/bitflags)
 
 - [Documentation](https://docs.rs/bitflags)
-- [Release notes](https://github.com/rust-lang-nursery/bitflags/releases)
+- [Release notes](https://github.com/bitflags/bitflags/releases)
 
 ## Usage
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -722,7 +722,7 @@ macro_rules! __impl_bitflags {
     // Debug and all() we want to ignore everything but #[cfg] attributes. In
     // particular, including a #[deprecated] attribute on those items would fail
     // to compile.
-    // https://github.com/rust-lang-nursery/bitflags/issues/109
+    // https://github.com/bitflags/bitflags/issues/109
     //
     // Input:
     //


### PR DESCRIPTION
Updating the references to the `bitflags` library so they point to this organization. I'll also take the opportunity to get Travis CI wired up.