### PR TITLE
Use local_inner_macros to resolve all helper macros within $crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ pub extern crate core as _core;
 ///     assert_eq!(format!("{:?}", Flags::B), "B");
 /// }
 /// ```
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! bitflags {
     (
         $(#[$outer:meta])*
@@ -386,7 +386,7 @@ macro_rules! bitflags {
     };
 }
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! __bitflags {
     (
@@ -415,7 +415,7 @@ macro_rules! __bitflags {
     };
 }
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! __impl_bitflags {
     (
@@ -467,14 +467,14 @@ macro_rules! __impl_bitflags {
                 $(
                     if <$BitFlags as __BitFlags>::$Flag(self) {
                         if !first {
-                            try!(f.write_str(" | "));
+                            f.write_str(" | ")?;
                         }
                         first = false;
-                        try!(f.write_str(stringify!($Flag)));
+                        f.write_str(__bitflags_stringify!($Flag))?;
                     }
                 )+
                 if first {
-                    try!(f.write_str("(empty)"));
+                    f.write_str("(empty)")?;
                 }
                 Ok(())
             }
@@ -768,6 +768,16 @@ macro_rules! __impl_bitflags {
     ) => {
         $(#[$filtered])*
         fn $($item)*
+    };
+}
+
+// Same as std::stringify but callable from __impl_bitflags, which needs to use
+// local_inner_macros so can only directly call macros from this crate.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __bitflags_stringify {
+    ($s:ident) => {
+        stringify!($s)
     };
 }
 


### PR DESCRIPTION
This fixes the following error when using Rust 2018 style macro imports.

```rust
use bitflags::bitflags;
```

```console
error: cannot find macro `__bitflags!` in this scope
  --> src/main.rs:5:1
   |
5  | / bitflags! {
6  | |     struct Flags: u32 {
7  | |         const A = 0b00000001;
8  | |         const B = 0b00000010;
...  |
11 | |     }
12 | | }
   | |_^ help: you could try the macro: `bitflags`
   |
```

The `local_inner_macros` modifier resolves all macro invocations made from within that macro as helpers in the same crate. So if `bitflags!` expands to an invocation of `__bitflags!` then this would be resolved as `$crate::__bitflags!` rather than requiring the caller to have `__bitflags` in scope.

The attribute is ignored by pre-2018 compilers so bitflags will continue to work as normal with #[macro_use].

In the future when dropping compatibility with pre-2018 compilers we can remove the `local_inner_macros` modifier and use our own explicit `$crate::` prefixes on invocations of helper macros.