### PR TITLE
WIP: Test using bitflags from 2018 edition

### DIFF
--- a/test_suite/tests/rust2018.rs
+++ b/test_suite/tests/rust2018.rs
@@ -1,0 +1,14 @@
+#![cfg(feature = "unstable")]
+#![edition = "2018"]
+#![feature(use_extern_macros)]
+
+use bitflags::bitflags;
+
+bitflags! {
+    struct Flags: u32 {
+        const A = 0b00000001;
+        const B = 0b00000010;
+        const C = 0b00000100;
+        const ABC = Self::A.bits | Self::B.bits | Self::C.bits;
+    }
+}


### PR DESCRIPTION
`#![edition = "2018"]` isn't a real thing yet. I will file a feature request.