### PR TITLE
WIP: enable 2018 edition for just one test case

### DIFF
--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -1,9 +1,15 @@
+cargo-features = ["edition"]
+
 [project]
 name = "test_suite"
 version = "0.0.0"
 
 [features]
 unstable = ["compiletest_rs"]
+
+[[test]]
+name = "rust2018"
+edition = "2018"
 
 [dependencies]
 bitflags = { path = "../" }

--- a/test_suite/tests/rust2018.rs
+++ b/test_suite/tests/rust2018.rs
@@ -1,0 +1,13 @@
+#![cfg(feature = "unstable")]
+#![feature(use_extern_macros)]
+
+use bitflags::bitflags;
+
+bitflags! {
+    struct Flags: u32 {
+        const A = 0b00000001;
+        const B = 0b00000010;
+        const C = 0b00000100;
+        const ABC = Self::A.bits | Self::B.bits | Self::C.bits;
+    }
+}


### PR DESCRIPTION
```toml
[[test]]
name = "rust2018"
edition = "2018"
```

^This is not a real thing yet. I will file a Cargo feature request to follow up.