### PR TITLE
const functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ exclude = [
     "appveyor.yml",
     "bors.toml"
 ]
+build = "build.rs"
 
 [badges]
 travis-ci = { repository = "bitflags/bitflags" }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,44 @@
+use std::env;
+use std::process::Command;
+use std::str::{self, FromStr};
+
+fn main(){
+    let minor = match rustc_minor_version() {
+        Some(minor) => minor,
+        None => return,
+    };
+
+    // const fn stabilized in Rust 1.31:
+    if minor >= 31 {
+        println!("cargo:rustc-cfg=const_fn");
+    }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    let rustc = match env::var_os("RUSTC") {
+        Some(rustc) => rustc,
+        None => return None,
+    };
+
+    let output = match Command::new(rustc).arg("--version").output() {
+        Ok(output) => output,
+        Err(_) => return None,
+    };
+
+    let version = match str::from_utf8(&output.stdout) {
+        Ok(version) => version,
+        Err(_) => return None,
+    };
+
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+
+    let next = match pieces.next() {
+        Some(next) => next,
+        None => return None,
+    };
+
+    u32::from_str(next).ok()
+}

--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,7 @@ fn main(){
 
     // const fn stabilized in Rust 1.31:
     if minor >= 31 {
-        println!("cargo:rustc-cfg=const_fn");
+        println!("cargo:rustc-cfg=bitflags_const_fn");
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,7 +418,7 @@ macro_rules! __bitflags {
 #[macro_export(local_inner_macros)]
 #[doc(hidden)]
 #[cfg(const_fn)]
-macro_rules! __fn {
+macro_rules! __fn_bitflags {
     (
         $(#[$filtered:meta])*
         fn $($item:tt)*
@@ -438,7 +438,7 @@ macro_rules! __fn {
 #[macro_export(local_inner_macros)]
 #[doc(hidden)]
 #[cfg(not(const_fn))]
-macro_rules! _fn {
+macro_rules! __fn_bitflags {
     (
         $(#[$filtered:meta])*
         fn $($item:tt)*
@@ -548,7 +548,7 @@ macro_rules! __impl_bitflags {
             )+
 
             /// Returns an empty set of flags.
-            __fn! {
+            __fn_bitflags! {
                 #[inline]
                 pub fn empty() -> $BitFlags {
                     $BitFlags { bits: 0 }
@@ -556,7 +556,7 @@ macro_rules! __impl_bitflags {
             }
 
             /// Returns the set containing all flags.
-            __fn! {
+            __fn_bitflags! {
                 #[inline]
                 pub fn all() -> $BitFlags {
                     // See `Debug::fmt` for why this approach is taken.
@@ -582,7 +582,7 @@ macro_rules! __impl_bitflags {
             }
 
             /// Returns the raw value of the flags currently stored.
-            __fn! {
+            __fn_bitflags! {
                 #[inline]
                 pub fn bits(&self) -> $T {
                     self.bits
@@ -602,7 +602,7 @@ macro_rules! __impl_bitflags {
 
             /// Convert from underlying bit representation, dropping any bits
             /// that do not correspond to flags.
-            __fn! {
+            __fn_bitflags! {
                 #[inline]
                 pub fn from_bits_truncate(bits: $T) -> $BitFlags {
                     $BitFlags { bits: bits & $BitFlags::all().bits }
@@ -610,7 +610,7 @@ macro_rules! __impl_bitflags {
             }
 
             /// Returns `true` if no flags are currently stored.
-            __fn! {
+            __fn_bitflags! {
                 #[inline]
                 pub fn is_empty(&self) -> bool {
                     self.bits() == $BitFlags::empty().bits()
@@ -618,7 +618,7 @@ macro_rules! __impl_bitflags {
             }
 
             /// Returns `true` if all flags are currently set.
-            __fn! {
+            __fn_bitflags! {
                 #[inline]
                 pub fn is_all(&self) -> bool {
                     self.bits == $BitFlags::all().bits
@@ -626,7 +626,7 @@ macro_rules! __impl_bitflags {
             }
 
             /// Returns `true` if there are flags common to both `self` and `other`.
-            __fn! {
+            __fn_bitflags! {
                 #[inline]
                 pub fn intersects(&self, other: $BitFlags) -> bool {
                     !$BitFlags{ bits: self.bits & other.bits}.is_empty()
@@ -634,7 +634,7 @@ macro_rules! __impl_bitflags {
             }
 
             /// Returns `true` all of the flags in `other` are contained within `self`.
-            __fn! {
+            __fn_bitflags! {
                 #[inline]
                 pub fn contains(&self, other: $BitFlags) -> bool {
                     (self.bits & other.bits) == other.bits
@@ -642,7 +642,7 @@ macro_rules! __impl_bitflags {
             }
 
             /// Joins to set of flags into a new one
-            __fn! {
+            __fn_bitflags! {
                 #[inline]
                 pub fn join(&self, other: $BitFlags) -> $BitFlags {
                     $BitFlags{ bits: self.bits | other.bits }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,18 +417,18 @@ macro_rules! __bitflags {
 
 #[macro_export(local_inner_macros)]
 #[doc(hidden)]
-#[cfg(const_fn)]
+#[cfg(bitflags_const_fn)]
 macro_rules! __fn_bitflags {
     (
         $(#[$filtered:meta])*
-        fn $($item:tt)*
+        const fn $($item:tt)*
     ) => {
         $(#[$filtered])*
         const fn $($item)*
     };
     (
         $(#[$filtered:meta])*
-        pub fn $($item:tt)*
+        pub const fn $($item:tt)*
     ) => {
         $(#[$filtered])*
         pub const fn $($item)*
@@ -437,18 +437,18 @@ macro_rules! __fn_bitflags {
 
 #[macro_export(local_inner_macros)]
 #[doc(hidden)]
-#[cfg(not(const_fn))]
+#[cfg(not(bitflags_const_fn))]
 macro_rules! __fn_bitflags {
     (
         $(#[$filtered:meta])*
-        fn $($item:tt)*
+        const fn $($item:tt)*
     ) => {
         $(#[$filtered])*
         fn $($item)*
     };
     (
         $(#[$filtered:meta])*
-        pub fn $($item:tt)*
+        pub const fn $($item:tt)*
     ) => {
         $(#[$filtered])*
         pub fn $($item)*
@@ -550,7 +550,7 @@ macro_rules! __impl_bitflags {
             /// Returns an empty set of flags.
             __fn_bitflags! {
                 #[inline]
-                pub fn empty() -> $BitFlags {
+                pub const fn empty() -> $BitFlags {
                     $BitFlags { bits: 0 }
                 }
             }
@@ -558,7 +558,7 @@ macro_rules! __impl_bitflags {
             /// Returns the set containing all flags.
             __fn_bitflags! {
                 #[inline]
-                pub fn all() -> $BitFlags {
+                pub const fn all() -> $BitFlags {
                     // See `Debug::fmt` for why this approach is taken.
                     #[allow(non_snake_case)]
                     trait __BitFlags {
@@ -584,7 +584,7 @@ macro_rules! __impl_bitflags {
             /// Returns the raw value of the flags currently stored.
             __fn_bitflags! {
                 #[inline]
-                pub fn bits(&self) -> $T {
+                pub const fn bits(&self) -> $T {
                     self.bits
                 }
             }
@@ -604,7 +604,7 @@ macro_rules! __impl_bitflags {
             /// that do not correspond to flags.
             __fn_bitflags! {
                 #[inline]
-                pub fn from_bits_truncate(bits: $T) -> $BitFlags {
+                pub const fn from_bits_truncate(bits: $T) -> $BitFlags {
                     $BitFlags { bits: bits & $BitFlags::all().bits }
                 }
             }
@@ -612,7 +612,7 @@ macro_rules! __impl_bitflags {
             /// Returns `true` if no flags are currently stored.
             __fn_bitflags! {
                 #[inline]
-                pub fn is_empty(&self) -> bool {
+                pub const fn is_empty(&self) -> bool {
                     self.bits() == $BitFlags::empty().bits()
                 }
             }
@@ -620,7 +620,7 @@ macro_rules! __impl_bitflags {
             /// Returns `true` if all flags are currently set.
             __fn_bitflags! {
                 #[inline]
-                pub fn is_all(&self) -> bool {
+                pub const fn is_all(&self) -> bool {
                     self.bits == $BitFlags::all().bits
                 }
             }
@@ -628,7 +628,7 @@ macro_rules! __impl_bitflags {
             /// Returns `true` if there are flags common to both `self` and `other`.
             __fn_bitflags! {
                 #[inline]
-                pub fn intersects(&self, other: $BitFlags) -> bool {
+                pub const fn intersects(&self, other: $BitFlags) -> bool {
                     !$BitFlags{ bits: self.bits & other.bits}.is_empty()
                 }
             }
@@ -636,16 +636,8 @@ macro_rules! __impl_bitflags {
             /// Returns `true` all of the flags in `other` are contained within `self`.
             __fn_bitflags! {
                 #[inline]
-                pub fn contains(&self, other: $BitFlags) -> bool {
+                pub const fn contains(&self, other: $BitFlags) -> bool {
                     (self.bits & other.bits) == other.bits
-                }
-            }
-
-            /// Joins to set of flags into a new one
-            __fn_bitflags! {
-                #[inline]
-                pub fn join(&self, other: $BitFlags) -> $BitFlags {
-                    $BitFlags{ bits: self.bits | other.bits }
                 }
             }
 
@@ -833,8 +825,6 @@ macro_rules! __impl_bitflags {
         $(#[$filtered])*
         fn $($item)*
     };
-
-
 
     // Every attribute that the user writes on a const is applied to the
     // corresponding const that we generate, but within the implementation of
@@ -1129,7 +1119,7 @@ mod tests {
     }
 
 
-    #[cfg(const_fn)]
+    #[cfg(bitflags_const_fn)]
     #[test]
     fn test_const_fn() {
         const M1: Flags = Flags::empty();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,17 +420,17 @@ macro_rules! __bitflags {
 #[cfg(bitflags_const_fn)]
 macro_rules! __fn_bitflags {
     (
-        $(#[$filtered:meta])*
+        $(#[$attr:ident $($attr_args:tt)*])*
         const fn $($item:tt)*
     ) => {
-        $(#[$filtered])*
+        $(#[$attr $($attr_args)*])*
         const fn $($item)*
     };
     (
-        $(#[$filtered:meta])*
+        $(#[$attr:ident $($attr_args:tt)*])*
         pub const fn $($item:tt)*
     ) => {
-        $(#[$filtered])*
+        $(#[$attr $($attr_args)*])*
         pub const fn $($item)*
     };
 }
@@ -440,17 +440,17 @@ macro_rules! __fn_bitflags {
 #[cfg(not(bitflags_const_fn))]
 macro_rules! __fn_bitflags {
     (
-        $(#[$filtered:meta])*
+        $(#[$attr:ident $($attr_args:tt)*])*
         const fn $($item:tt)*
     ) => {
-        $(#[$filtered])*
+        $(#[$attr $($attr_args)*])*
         fn $($item)*
     };
     (
-        $(#[$filtered:meta])*
+        $(#[$attr:ident $($attr_args:tt)*])*
         pub const fn $($item:tt)*
     ) => {
-        $(#[$filtered])*
+        $(#[$attr $($attr_args)*])*
         pub fn $($item)*
     };
 }
@@ -547,16 +547,16 @@ macro_rules! __impl_bitflags {
                 pub const $Flag: $BitFlags = $BitFlags { bits: $value };
             )+
 
-            /// Returns an empty set of flags.
             __fn_bitflags! {
+                /// Returns an empty set of flags
                 #[inline]
                 pub const fn empty() -> $BitFlags {
                     $BitFlags { bits: 0 }
                 }
             }
 
-            /// Returns the set containing all flags.
             __fn_bitflags! {
+                /// Returns the set containing all flags.
                 #[inline]
                 pub const fn all() -> $BitFlags {
                     // See `Debug::fmt` for why this approach is taken.
@@ -581,8 +581,8 @@ macro_rules! __impl_bitflags {
                 }
             }
 
-            /// Returns the raw value of the flags currently stored.
             __fn_bitflags! {
+                /// Returns the raw value of the flags currently stored.
                 #[inline]
                 pub const fn bits(&self) -> $T {
                     self.bits
@@ -600,41 +600,41 @@ macro_rules! __impl_bitflags {
                 }
             }
 
+            __fn_bitflags! {
             /// Convert from underlying bit representation, dropping any bits
             /// that do not correspond to flags.
-            __fn_bitflags! {
                 #[inline]
                 pub const fn from_bits_truncate(bits: $T) -> $BitFlags {
                     $BitFlags { bits: bits & $BitFlags::all().bits }
                 }
             }
 
-            /// Returns `true` if no flags are currently stored.
             __fn_bitflags! {
+                /// Returns `true` if no flags are currently stored.
                 #[inline]
                 pub const fn is_empty(&self) -> bool {
                     self.bits() == $BitFlags::empty().bits()
                 }
             }
 
-            /// Returns `true` if all flags are currently set.
             __fn_bitflags! {
+                /// Returns `true` if all flags are currently set.
                 #[inline]
                 pub const fn is_all(&self) -> bool {
                     self.bits == $BitFlags::all().bits
                 }
             }
 
-            /// Returns `true` if there are flags common to both `self` and `other`.
             __fn_bitflags! {
+            /// Returns `true` if there are flags common to both `self` and `other`.
                 #[inline]
                 pub const fn intersects(&self, other: $BitFlags) -> bool {
                     !$BitFlags{ bits: self.bits & other.bits}.is_empty()
                 }
             }
 
-            /// Returns `true` all of the flags in `other` are contained within `self`.
             __fn_bitflags! {
+            /// Returns `true` all of the flags in `other` are contained within `self`.
                 #[inline]
                 pub const fn contains(&self, other: $BitFlags) -> bool {
                     (self.bits & other.bits) == other.bits

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1107,6 +1107,19 @@ mod tests {
         assert_eq!(m1, e1);
     }
 
+
+    #[cfg(bitflags_const_fn)]
+    #[test]
+    fn test_const_fn() {
+        const M1: Flags = Flags::empty();
+
+        const M2: Flags = Flags::A;
+        assert_eq!(M2, Flags::A);
+
+        const M3: Flags = Flags::C;
+        assert_eq!(M3, Flags::C);
+    }
+
     #[test]
     fn test_extend() {
         let mut flags;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1439,13 +1439,13 @@ mod tests {
     #[cfg(const_fn)]
     #[test]
     fn test_const_fn() {
-        const m1: Flags = Flags::empty();
+        const M1: Flags = Flags::empty();
 
-        const m2: Flags = m1.join(Flags::A);
-        assert_eq!(m2, Flags::A);
+        const M2: Flags = M1.join(Flags::A);
+        assert_eq!(M2, Flags::A);
 
-        const m3: Flags = m1.join(Flags::A).join(Flags::C);
-        assert_eq!(m3, Flags::A | Flags::C);
+        const M3: Flags = M1.join(Flags::A).join(Flags::C);
+        assert_eq!(M3, Flags::A | Flags::C);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -440,17 +440,17 @@ macro_rules! __fn_bitflags {
 #[cfg(not(bitflags_const_fn))]
 macro_rules! __fn_bitflags {
     (
-        $(#[$attr:ident $($attr_args:tt)*])*
+        # $($attr_args:tt)*
         const fn $($item:tt)*
     ) => {
-        $(#[$attr $($attr_args)*])*
+        # $($attr_args)*
         fn $($item)*
     };
     (
-        $(#[$attr:ident $($attr_args:tt)*])*
+        # $($attr_args:tt)*
         pub const fn $($item:tt)*
     ) => {
-        $(#[$attr $($attr_args)*])*
+        # $($attr_args)*
         pub fn $($item)*
     };
 }
@@ -601,8 +601,8 @@ macro_rules! __impl_bitflags {
             }
 
             __fn_bitflags! {
-            /// Convert from underlying bit representation, dropping any bits
-            /// that do not correspond to flags.
+                /// Convert from underlying bit representation, dropping any bits
+                /// that do not correspond to flags.
                 #[inline]
                 pub const fn from_bits_truncate(bits: $T) -> $BitFlags {
                     $BitFlags { bits: bits & $BitFlags::all().bits }
@@ -626,7 +626,7 @@ macro_rules! __impl_bitflags {
             }
 
             __fn_bitflags! {
-            /// Returns `true` if there are flags common to both `self` and `other`.
+                /// Returns `true` if there are flags common to both `self` and `other`.
                 #[inline]
                 pub const fn intersects(&self, other: $BitFlags) -> bool {
                     !$BitFlags{ bits: self.bits & other.bits}.is_empty()
@@ -634,7 +634,7 @@ macro_rules! __impl_bitflags {
             }
 
             __fn_bitflags! {
-            /// Returns `true` all of the flags in `other` are contained within `self`.
+                /// Returns `true` all of the flags in `other` are contained within `self`.
                 #[inline]
                 pub const fn contains(&self, other: $BitFlags) -> bool {
                     (self.bits & other.bits) == other.bits

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,6 +418,45 @@ macro_rules! __bitflags {
 #[macro_export(local_inner_macros)]
 #[doc(hidden)]
 #[cfg(const_fn)]
+macro_rules! __fn {
+    (
+        $(#[$filtered:meta])*
+        fn $($item:tt)*
+    ) => {
+        $(#[$filtered])*
+        const fn $($item)*
+    };
+    (
+        $(#[$filtered:meta])*
+        pub fn $($item:tt)*
+    ) => {
+        $(#[$filtered])*
+        pub const fn $($item)*
+    };
+}
+
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+#[cfg(not(const_fn))]
+macro_rules! _fn {
+    (
+        $(#[$filtered:meta])*
+        fn $($item:tt)*
+    ) => {
+        $(#[$filtered])*
+        fn $($item)*
+    };
+    (
+        $(#[$filtered:meta])*
+        pub fn $($item:tt)*
+    ) => {
+        $(#[$filtered])*
+        pub fn $($item)*
+    };
+}
+
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
 macro_rules! __impl_bitflags {
     (
         $BitFlags:ident: $T:ty {
@@ -509,39 +548,45 @@ macro_rules! __impl_bitflags {
             )+
 
             /// Returns an empty set of flags.
-            #[inline]
-            pub const fn empty() -> $BitFlags {
-                $BitFlags { bits: 0 }
+            __fn! {
+                #[inline]
+                pub fn empty() -> $BitFlags {
+                    $BitFlags { bits: 0 }
+                }
             }
 
             /// Returns the set containing all flags.
-            #[inline]
-            pub const fn all() -> $BitFlags {
-                // See `Debug::fmt` for why this approach is taken.
-                #[allow(non_snake_case)]
-                trait __BitFlags {
-                    $(
-                        #[inline]
-                        const $Flag: $T = 0;
-                    )+
-                }
-                impl __BitFlags for $BitFlags {
-                    $(
-                        __impl_bitflags! {
-                            #[allow(deprecated)]
+            __fn! {
+                #[inline]
+                pub fn all() -> $BitFlags {
+                    // See `Debug::fmt` for why this approach is taken.
+                    #[allow(non_snake_case)]
+                    trait __BitFlags {
+                        $(
                             #[inline]
-                            $(? #[$attr $($args)*])*
-                            const $Flag: $T = Self::$Flag.bits;
-                        }
-                    )+
+                            const $Flag: $T = 0;
+                        )+
+                    }
+                    impl __BitFlags for $BitFlags {
+                        $(
+                            __impl_bitflags! {
+                                #[allow(deprecated)]
+                                #[inline]
+                                $(? #[$attr $($args)*])*
+                                const $Flag: $T = Self::$Flag.bits;
+                            }
+                        )+
+                    }
+                    $BitFlags { bits: $(<$BitFlags as __BitFlags>::$Flag)|+ }
                 }
-                $BitFlags { bits: $(<$BitFlags as __BitFlags>::$Flag)|+ }
             }
 
             /// Returns the raw value of the flags currently stored.
-            #[inline]
-            pub const fn bits(&self) -> $T {
-                self.bits
+            __fn! {
+                #[inline]
+                pub fn bits(&self) -> $T {
+                    self.bits
+                }
             }
 
             /// Convert from underlying bit representation, unless that
@@ -557,39 +602,51 @@ macro_rules! __impl_bitflags {
 
             /// Convert from underlying bit representation, dropping any bits
             /// that do not correspond to flags.
-            #[inline]
-            pub const fn from_bits_truncate(bits: $T) -> $BitFlags {
-                $BitFlags { bits: bits & $BitFlags::all().bits }
+            __fn! {
+                #[inline]
+                pub fn from_bits_truncate(bits: $T) -> $BitFlags {
+                    $BitFlags { bits: bits & $BitFlags::all().bits }
+                }
             }
 
             /// Returns `true` if no flags are currently stored.
-            #[inline]
-            pub const fn is_empty(&self) -> bool {
-                self.bits() == $BitFlags::empty().bits()
+            __fn! {
+                #[inline]
+                pub fn is_empty(&self) -> bool {
+                    self.bits() == $BitFlags::empty().bits()
+                }
             }
 
             /// Returns `true` if all flags are currently set.
-            #[inline]
-            pub const fn is_all(&self) -> bool {
-                self.bits == $BitFlags::all().bits
+            __fn! {
+                #[inline]
+                pub fn is_all(&self) -> bool {
+                    self.bits == $BitFlags::all().bits
+                }
             }
 
             /// Returns `true` if there are flags common to both `self` and `other`.
-            #[inline]
-            pub const fn intersects(&self, other: $BitFlags) -> bool {
-                !$BitFlags{ bits: self.bits & other.bits}.is_empty()
+            __fn! {
+                #[inline]
+                pub fn intersects(&self, other: $BitFlags) -> bool {
+                    !$BitFlags{ bits: self.bits & other.bits}.is_empty()
+                }
             }
 
             /// Returns `true` all of the flags in `other` are contained within `self`.
-            #[inline]
-            pub const fn contains(&self, other: $BitFlags) -> bool {
-                (self.bits & other.bits) == other.bits
+            __fn! {
+                #[inline]
+                pub fn contains(&self, other: $BitFlags) -> bool {
+                    (self.bits & other.bits) == other.bits
+                }
             }
 
             /// Joins to set of flags into a new one
-            #[inline]
-            pub const fn join(&self, other: $BitFlags) -> $BitFlags {
-                $BitFlags{ bits: self.bits | other.bits }
+            __fn! {
+                #[inline]
+                pub fn join(&self, other: $BitFlags) -> $BitFlags {
+                    $BitFlags{ bits: self.bits | other.bits }
+                }
             }
 
             /// Inserts the specified flags in-place.
@@ -832,370 +889,6 @@ macro_rules! __impl_bitflags {
     ) => {
         $(#[$filtered])*
         const $($item)*
-    };
-}
-
-
-#[macro_export(local_inner_macros)]
-#[doc(hidden)]
-#[cfg(not(const_fn))]
-macro_rules! __impl_bitflags {
-    (
-        $BitFlags:ident: $T:ty {
-            $(
-                $(#[$attr:ident $($args:tt)*])*
-                $Flag:ident = $value:expr;
-            )+
-        }
-    ) => {
-        impl $crate::_core::fmt::Debug for $BitFlags {
-            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
-                // This convoluted approach is to handle #[cfg]-based flag
-                // omission correctly. For example it needs to support:
-                //
-                //    #[cfg(unix)] const A: Flag = /* ... */;
-                //    #[cfg(windows)] const B: Flag = /* ... */;
-
-                // Unconditionally define a check for every flag, even disabled
-                // ones.
-                #[allow(non_snake_case)]
-                trait __BitFlags {
-                    $(
-                        #[inline]
-                        fn $Flag(&self) -> bool { false }
-                    )+
-                }
-
-                // Conditionally override the check for just those flags that
-                // are not #[cfg]ed away.
-                impl __BitFlags for $BitFlags {
-                    $(
-                        __impl_bitflags! {
-                            #[allow(deprecated)]
-                            #[inline]
-                            $(? #[$attr $($args)*])*
-                            fn $Flag(&self) -> bool {
-                                if Self::$Flag.bits == 0 && self.bits != 0 {
-                                    false
-                                } else {
-                                    self.bits & Self::$Flag.bits == Self::$Flag.bits
-                                }
-                            }
-                        }
-                    )+
-                }
-
-                let mut first = true;
-                $(
-                    if <$BitFlags as __BitFlags>::$Flag(self) {
-                        if !first {
-                            f.write_str(" | ")?;
-                        }
-                        first = false;
-                        f.write_str(__bitflags_stringify!($Flag))?;
-                    }
-                )+
-                if first {
-                    f.write_str("(empty)")?;
-                }
-                Ok(())
-            }
-        }
-        impl $crate::_core::fmt::Binary for $BitFlags {
-            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
-                $crate::_core::fmt::Binary::fmt(&self.bits, f)
-            }
-        }
-        impl $crate::_core::fmt::Octal for $BitFlags {
-            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
-                $crate::_core::fmt::Octal::fmt(&self.bits, f)
-            }
-        }
-        impl $crate::_core::fmt::LowerHex for $BitFlags {
-            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
-                $crate::_core::fmt::LowerHex::fmt(&self.bits, f)
-            }
-        }
-        impl $crate::_core::fmt::UpperHex for $BitFlags {
-            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
-                $crate::_core::fmt::UpperHex::fmt(&self.bits, f)
-            }
-        }
-
-        #[allow(dead_code)]
-        impl $BitFlags {
-            $(
-                $(#[$attr $($args)*])*
-                pub const $Flag: $BitFlags = $BitFlags { bits: $value };
-            )+
-
-            /// Returns an empty set of flags.
-            #[inline]
-            pub fn empty() -> $BitFlags {
-                $BitFlags { bits: 0 }
-            }
-
-            /// Returns the set containing all flags.
-            #[inline]
-            pub fn all() -> $BitFlags {
-                // See `Debug::fmt` for why this approach is taken.
-                #[allow(non_snake_case)]
-                trait __BitFlags {
-                    $(
-                        #[inline]
-                        fn $Flag() -> $T { 0 }
-                    )+
-                }
-                impl __BitFlags for $BitFlags {
-                    $(
-                        __impl_bitflags! {
-                            #[allow(deprecated)]
-                            #[inline]
-                            $(? #[$attr $($args)*])*
-                            fn $Flag() -> $T { Self::$Flag.bits }
-                        }
-                    )+
-                }
-                $BitFlags { bits: $(<$BitFlags as __BitFlags>::$Flag())|+ }
-            }
-
-            /// Returns the raw value of the flags currently stored.
-            #[inline]
-            pub fn bits(&self) -> $T {
-                self.bits
-            }
-
-            /// Convert from underlying bit representation, unless that
-            /// representation contains bits that do not correspond to a flag.
-            #[inline]
-            pub fn from_bits(bits: $T) -> $crate::_core::option::Option<$BitFlags> {
-                if (bits & !$BitFlags::all().bits()) == 0 {
-                    $crate::_core::option::Option::Some($BitFlags { bits })
-                } else {
-                    $crate::_core::option::Option::None
-                }
-            }
-
-            /// Convert from underlying bit representation, dropping any bits
-            /// that do not correspond to flags.
-            #[inline]
-            pub fn from_bits_truncate(bits: $T) -> $BitFlags {
-                $BitFlags { bits } & $BitFlags::all()
-            }
-
-            /// Returns `true` if no flags are currently stored.
-            #[inline]
-            pub fn is_empty(&self) -> bool {
-                *self == $BitFlags::empty()
-            }
-
-            /// Returns `true` if all flags are currently set.
-            #[inline]
-            pub fn is_all(&self) -> bool {
-                *self == $BitFlags::all()
-            }
-
-            /// Returns `true` if there are flags common to both `self` and `other`.
-            #[inline]
-            pub fn intersects(&self, other: $BitFlags) -> bool {
-                !(*self & other).is_empty()
-            }
-
-            /// Returns `true` all of the flags in `other` are contained within `self`.
-            #[inline]
-            pub fn contains(&self, other: $BitFlags) -> bool {
-                (*self & other) == other
-            }
-
-            /// Joins to set of flags into a new one
-            #[inline]
-            pub fn join(&self, other: $BitFlags) -> $BitFlags {
-                *self | other
-            }
-
-            /// Inserts the specified flags in-place.
-            #[inline]
-            pub fn insert(&mut self, other: $BitFlags) {
-                self.bits |= other.bits;
-            }
-
-            /// Removes the specified flags in-place.
-            #[inline]
-            pub fn remove(&mut self, other: $BitFlags) {
-                self.bits &= !other.bits;
-            }
-
-            /// Toggles the specified flags in-place.
-            #[inline]
-            pub fn toggle(&mut self, other: $BitFlags) {
-                self.bits ^= other.bits;
-            }
-
-            /// Inserts or removes the specified flags depending on the passed value.
-            #[inline]
-            pub fn set(&mut self, other: $BitFlags, value: bool) {
-                if value {
-                    self.insert(other);
-                } else {
-                    self.remove(other);
-                }
-            }
-        }
-
-        impl $crate::_core::ops::BitOr for $BitFlags {
-            type Output = $BitFlags;
-
-            /// Returns the union of the two sets of flags.
-            #[inline]
-            fn bitor(self, other: $BitFlags) -> $BitFlags {
-                $BitFlags { bits: self.bits | other.bits }
-            }
-        }
-
-        impl $crate::_core::ops::BitOrAssign for $BitFlags {
-
-            /// Adds the set of flags.
-            #[inline]
-            fn bitor_assign(&mut self, other: $BitFlags) {
-                self.bits |= other.bits;
-            }
-        }
-
-        impl $crate::_core::ops::BitXor for $BitFlags {
-            type Output = $BitFlags;
-
-            /// Returns the left flags, but with all the right flags toggled.
-            #[inline]
-            fn bitxor(self, other: $BitFlags) -> $BitFlags {
-                $BitFlags { bits: self.bits ^ other.bits }
-            }
-        }
-
-        impl $crate::_core::ops::BitXorAssign for $BitFlags {
-
-            /// Toggles the set of flags.
-            #[inline]
-            fn bitxor_assign(&mut self, other: $BitFlags) {
-                self.bits ^= other.bits;
-            }
-        }
-
-        impl $crate::_core::ops::BitAnd for $BitFlags {
-            type Output = $BitFlags;
-
-            /// Returns the intersection between the two sets of flags.
-            #[inline]
-            fn bitand(self, other: $BitFlags) -> $BitFlags {
-                $BitFlags { bits: self.bits & other.bits }
-            }
-        }
-
-        impl $crate::_core::ops::BitAndAssign for $BitFlags {
-
-            /// Disables all flags disabled in the set.
-            #[inline]
-            fn bitand_assign(&mut self, other: $BitFlags) {
-                self.bits &= other.bits;
-            }
-        }
-
-        impl $crate::_core::ops::Sub for $BitFlags {
-            type Output = $BitFlags;
-
-            /// Returns the set difference of the two sets of flags.
-            #[inline]
-            fn sub(self, other: $BitFlags) -> $BitFlags {
-                $BitFlags { bits: self.bits & !other.bits }
-            }
-        }
-
-        impl $crate::_core::ops::SubAssign for $BitFlags {
-
-            /// Disables all flags enabled in the set.
-            #[inline]
-            fn sub_assign(&mut self, other: $BitFlags) {
-                self.bits &= !other.bits;
-            }
-        }
-
-        impl $crate::_core::ops::Not for $BitFlags {
-            type Output = $BitFlags;
-
-            /// Returns the complement of this set of flags.
-            #[inline]
-            fn not(self) -> $BitFlags {
-                $BitFlags { bits: !self.bits } & $BitFlags::all()
-            }
-        }
-
-        impl $crate::_core::iter::Extend<$BitFlags> for $BitFlags {
-            fn extend<T: $crate::_core::iter::IntoIterator<Item=$BitFlags>>(&mut self, iterator: T) {
-                for item in iterator {
-                    self.insert(item)
-                }
-            }
-        }
-
-        impl $crate::_core::iter::FromIterator<$BitFlags> for $BitFlags {
-            fn from_iter<T: $crate::_core::iter::IntoIterator<Item=$BitFlags>>(iterator: T) -> $BitFlags {
-                let mut result = Self::empty();
-                result.extend(iterator);
-                result
-            }
-        }
-    };
-
-    // Every attribute that the user writes on a const is applied to the
-    // corresponding const that we generate, but within the implementation of
-    // Debug and all() we want to ignore everything but #[cfg] attributes. In
-    // particular, including a #[deprecated] attribute on those items would fail
-    // to compile.
-    // https://github.com/bitflags/bitflags/issues/109
-    //
-    // Input:
-    //
-    //     ? #[cfg(feature = "advanced")]
-    //     ? #[deprecated(note = "Use somthing else.")]
-    //     ? #[doc = r"High quality documentation."]
-    //     fn f() -> i32 { /* ... */ }
-    //
-    // Output:
-    //
-    //     #[cfg(feature = "advanced")]
-    //     fn f() -> i32 { /* ... */ }
-    (
-        $(#[$filtered:meta])*
-        ? #[cfg $($cfgargs:tt)*]
-        $(? #[$rest:ident $($restargs:tt)*])*
-        fn $($item:tt)*
-    ) => {
-        __impl_bitflags! {
-            $(#[$filtered])*
-            #[cfg $($cfgargs)*]
-            $(? #[$rest $($restargs)*])*
-            fn $($item)*
-        }
-    };
-    (
-        $(#[$filtered:meta])*
-        // $next != `cfg`
-        ? #[$next:ident $($nextargs:tt)*]
-        $(? #[$rest:ident $($restargs:tt)*])*
-        fn $($item:tt)*
-    ) => {
-        __impl_bitflags! {
-            $(#[$filtered])*
-            // $next filtered out
-            $(? #[$rest $($restargs)*])*
-            fn $($item)*
-        }
-    };
-    (
-        $(#[$filtered:meta])*
-        fn $($item:tt)*
-    ) => {
-        $(#[$filtered])*
-        fn $($item)*
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1108,30 +1108,6 @@ mod tests {
     }
 
     #[test]
-    fn test_join() {
-        let mut m1 = Flags::empty();
-
-        m1 = m1.join(Flags::A);
-        assert_eq!(m1, Flags::A);
-
-        m1 = m1.join(Flags::C);
-        assert_eq!(m1, Flags::A | Flags::C);
-    }
-
-
-    #[cfg(bitflags_const_fn)]
-    #[test]
-    fn test_const_fn() {
-        const M1: Flags = Flags::empty();
-
-        const M2: Flags = M1.join(Flags::A);
-        assert_eq!(M2, Flags::A);
-
-        const M3: Flags = M1.join(Flags::A).join(Flags::C);
-        assert_eq!(M3, Flags::A | Flags::C);
-    }
-
-    #[test]
     fn test_extend() {
         let mut flags;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,6 +417,7 @@ macro_rules! __bitflags {
 
 #[macro_export(local_inner_macros)]
 #[doc(hidden)]
+#[cfg(const_fn)]
 macro_rules! __impl_bitflags {
     (
         $BitFlags:ident: $T:ty {
@@ -508,21 +509,12 @@ macro_rules! __impl_bitflags {
             )+
 
             /// Returns an empty set of flags.
-            #[cfg(const_fn)]
             #[inline]
             pub const fn empty() -> $BitFlags {
                 $BitFlags { bits: 0 }
             }
 
-            /// Returns an empty set of flags.
-            #[cfg(not(const_fn))]
-            #[inline]
-            pub fn empty() -> $BitFlags {
-                $BitFlags { bits: 0 }
-            }
-
             /// Returns the set containing all flags.
-            #[cfg(const_fn)]
             #[inline]
             pub const fn all() -> $BitFlags {
                 // See `Debug::fmt` for why this approach is taken.
@@ -546,42 +538,9 @@ macro_rules! __impl_bitflags {
                 $BitFlags { bits: $(<$BitFlags as __BitFlags>::$Flag)|+ }
             }
 
-            /// Returns the set containing all flags.
-            #[cfg(not(const_fn))]
-            #[inline]
-            pub fn all() -> $BitFlags {
-                // See `Debug::fmt` for why this approach is taken.
-                #[allow(non_snake_case)]
-                trait __BitFlags {
-                    $(
-                        #[inline]
-                        fn $Flag() -> $T { 0 }
-                    )+
-                }
-                impl __BitFlags for $BitFlags {
-                    $(
-                        __impl_bitflags! {
-                            #[allow(deprecated)]
-                            #[inline]
-                            $(? #[$attr $($args)*])*
-                            fn $Flag() -> $T { Self::$Flag.bits }
-                        }
-                    )+
-                }
-                $BitFlags { bits: $(<$BitFlags as __BitFlags>::$Flag())|+ }
-            }
-
             /// Returns the raw value of the flags currently stored.
-            #[cfg(const_fn)]
             #[inline]
             pub const fn bits(&self) -> $T {
-                self.bits
-            }
-
-            /// Returns the raw value of the flags currently stored.
-            #[cfg(not(const_fn))]
-            #[inline]
-            pub fn bits(&self) -> $T {
                 self.bits
             }
 
@@ -598,88 +557,39 @@ macro_rules! __impl_bitflags {
 
             /// Convert from underlying bit representation, dropping any bits
             /// that do not correspond to flags.
-            #[cfg(const_fn)]
             #[inline]
             pub const fn from_bits_truncate(bits: $T) -> $BitFlags {
                 $BitFlags { bits: bits & $BitFlags::all().bits }
             }
 
-            /// Convert from underlying bit representation, dropping any bits
-            /// that do not correspond to flags.
-            #[cfg(not(const_fn))]
-            #[inline]
-            pub fn from_bits_truncate(bits: $T) -> $BitFlags {
-                $BitFlags { bits } & $BitFlags::all()
-            }
-
             /// Returns `true` if no flags are currently stored.
-            #[cfg(const_fn)]
             #[inline]
             pub const fn is_empty(&self) -> bool {
                 self.bits() == $BitFlags::empty().bits()
             }
 
-            /// Returns `true` if no flags are currently stored.
-            #[cfg(not(const_fn))]
-            #[inline]
-            pub fn is_empty(&self) -> bool {
-                *self == $BitFlags::empty()
-            }
-
             /// Returns `true` if all flags are currently set.
-            #[cfg(const_fn)]
             #[inline]
             pub const fn is_all(&self) -> bool {
                 self.bits == $BitFlags::all().bits
             }
 
-            /// Returns `true` if all flags are currently set.
-            #[cfg(not(const_fn))]
-            #[inline]
-            pub fn is_all(&self) -> bool {
-                *self == $BitFlags::all()
-            }
-
             /// Returns `true` if there are flags common to both `self` and `other`.
-            #[cfg(const_fn)]
             #[inline]
             pub const fn intersects(&self, other: $BitFlags) -> bool {
                 !$BitFlags{ bits: self.bits & other.bits}.is_empty()
             }
 
-            /// Returns `true` if there are flags common to both `self` and `other`.
-            #[cfg(not(const_fn))]
-            #[inline]
-            pub fn intersects(&self, other: $BitFlags) -> bool {
-                !(*self & other).is_empty()
-            }
-
             /// Returns `true` all of the flags in `other` are contained within `self`.
-            #[cfg(const_fn)]
             #[inline]
             pub const fn contains(&self, other: $BitFlags) -> bool {
                 (self.bits & other.bits) == other.bits
             }
 
-            /// Returns `true` all of the flags in `other` are contained within `self`.
-            #[cfg(not(const_fn))]
-            #[inline]
-            pub fn contains(&self, other: $BitFlags) -> bool {
-                (*self & other) == other
-            }
-
             /// Joins to set of flags into a new one
-            #[cfg(const_fn)]
             #[inline]
             pub const fn join(&self, other: $BitFlags) -> $BitFlags {
                 $BitFlags{ bits: self.bits | other.bits }
-            }
-
-            /// Joins to set of flags into a new one
-            #[cfg(not(const_fn))]
-            #[inline]
-            pub fn join(&self, other: $BitFlags) -> $BitFlags {
-                *self | other
             }
 
             /// Inserts the specified flags in-place.
@@ -868,6 +778,27 @@ macro_rules! __impl_bitflags {
     };
 
 
+
+    // Every attribute that the user writes on a const is applied to the
+    // corresponding const that we generate, but within the implementation of
+    // Debug and all() we want to ignore everything but #[cfg] attributes. In
+    // particular, including a #[deprecated] attribute on those items would fail
+    // to compile.
+    // https://github.com/bitflags/bitflags/issues/109
+    //
+    // const version
+    //
+    // Input:
+    //
+    //     ? #[cfg(feature = "advanced")]
+    //     ? #[deprecated(note = "Use somthing else.")]
+    //     ? #[doc = r"High quality documentation."]
+    //     const f: i32 { /* ... */ }
+    //
+    // Output:
+    //
+    //     #[cfg(feature = "advanced")]
+    //     const f: i32 { /* ... */ }
     (
         $(#[$filtered:meta])*
         ? #[cfg $($cfgargs:tt)*]
@@ -901,6 +832,370 @@ macro_rules! __impl_bitflags {
     ) => {
         $(#[$filtered])*
         const $($item)*
+    };
+}
+
+
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+#[cfg(not(const_fn))]
+macro_rules! __impl_bitflags {
+    (
+        $BitFlags:ident: $T:ty {
+            $(
+                $(#[$attr:ident $($args:tt)*])*
+                $Flag:ident = $value:expr;
+            )+
+        }
+    ) => {
+        impl $crate::_core::fmt::Debug for $BitFlags {
+            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
+                // This convoluted approach is to handle #[cfg]-based flag
+                // omission correctly. For example it needs to support:
+                //
+                //    #[cfg(unix)] const A: Flag = /* ... */;
+                //    #[cfg(windows)] const B: Flag = /* ... */;
+
+                // Unconditionally define a check for every flag, even disabled
+                // ones.
+                #[allow(non_snake_case)]
+                trait __BitFlags {
+                    $(
+                        #[inline]
+                        fn $Flag(&self) -> bool { false }
+                    )+
+                }
+
+                // Conditionally override the check for just those flags that
+                // are not #[cfg]ed away.
+                impl __BitFlags for $BitFlags {
+                    $(
+                        __impl_bitflags! {
+                            #[allow(deprecated)]
+                            #[inline]
+                            $(? #[$attr $($args)*])*
+                            fn $Flag(&self) -> bool {
+                                if Self::$Flag.bits == 0 && self.bits != 0 {
+                                    false
+                                } else {
+                                    self.bits & Self::$Flag.bits == Self::$Flag.bits
+                                }
+                            }
+                        }
+                    )+
+                }
+
+                let mut first = true;
+                $(
+                    if <$BitFlags as __BitFlags>::$Flag(self) {
+                        if !first {
+                            f.write_str(" | ")?;
+                        }
+                        first = false;
+                        f.write_str(__bitflags_stringify!($Flag))?;
+                    }
+                )+
+                if first {
+                    f.write_str("(empty)")?;
+                }
+                Ok(())
+            }
+        }
+        impl $crate::_core::fmt::Binary for $BitFlags {
+            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
+                $crate::_core::fmt::Binary::fmt(&self.bits, f)
+            }
+        }
+        impl $crate::_core::fmt::Octal for $BitFlags {
+            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
+                $crate::_core::fmt::Octal::fmt(&self.bits, f)
+            }
+        }
+        impl $crate::_core::fmt::LowerHex for $BitFlags {
+            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
+                $crate::_core::fmt::LowerHex::fmt(&self.bits, f)
+            }
+        }
+        impl $crate::_core::fmt::UpperHex for $BitFlags {
+            fn fmt(&self, f: &mut $crate::_core::fmt::Formatter) -> $crate::_core::fmt::Result {
+                $crate::_core::fmt::UpperHex::fmt(&self.bits, f)
+            }
+        }
+
+        #[allow(dead_code)]
+        impl $BitFlags {
+            $(
+                $(#[$attr $($args)*])*
+                pub const $Flag: $BitFlags = $BitFlags { bits: $value };
+            )+
+
+            /// Returns an empty set of flags.
+            #[inline]
+            pub fn empty() -> $BitFlags {
+                $BitFlags { bits: 0 }
+            }
+
+            /// Returns the set containing all flags.
+            #[inline]
+            pub fn all() -> $BitFlags {
+                // See `Debug::fmt` for why this approach is taken.
+                #[allow(non_snake_case)]
+                trait __BitFlags {
+                    $(
+                        #[inline]
+                        fn $Flag() -> $T { 0 }
+                    )+
+                }
+                impl __BitFlags for $BitFlags {
+                    $(
+                        __impl_bitflags! {
+                            #[allow(deprecated)]
+                            #[inline]
+                            $(? #[$attr $($args)*])*
+                            fn $Flag() -> $T { Self::$Flag.bits }
+                        }
+                    )+
+                }
+                $BitFlags { bits: $(<$BitFlags as __BitFlags>::$Flag())|+ }
+            }
+
+            /// Returns the raw value of the flags currently stored.
+            #[inline]
+            pub fn bits(&self) -> $T {
+                self.bits
+            }
+
+            /// Convert from underlying bit representation, unless that
+            /// representation contains bits that do not correspond to a flag.
+            #[inline]
+            pub fn from_bits(bits: $T) -> $crate::_core::option::Option<$BitFlags> {
+                if (bits & !$BitFlags::all().bits()) == 0 {
+                    $crate::_core::option::Option::Some($BitFlags { bits })
+                } else {
+                    $crate::_core::option::Option::None
+                }
+            }
+
+            /// Convert from underlying bit representation, dropping any bits
+            /// that do not correspond to flags.
+            #[inline]
+            pub fn from_bits_truncate(bits: $T) -> $BitFlags {
+                $BitFlags { bits } & $BitFlags::all()
+            }
+
+            /// Returns `true` if no flags are currently stored.
+            #[inline]
+            pub fn is_empty(&self) -> bool {
+                *self == $BitFlags::empty()
+            }
+
+            /// Returns `true` if all flags are currently set.
+            #[inline]
+            pub fn is_all(&self) -> bool {
+                *self == $BitFlags::all()
+            }
+
+            /// Returns `true` if there are flags common to both `self` and `other`.
+            #[inline]
+            pub fn intersects(&self, other: $BitFlags) -> bool {
+                !(*self & other).is_empty()
+            }
+
+            /// Returns `true` all of the flags in `other` are contained within `self`.
+            #[inline]
+            pub fn contains(&self, other: $BitFlags) -> bool {
+                (*self & other) == other
+            }
+
+            /// Joins to set of flags into a new one
+            #[inline]
+            pub fn join(&self, other: $BitFlags) -> $BitFlags {
+                *self | other
+            }
+
+            /// Inserts the specified flags in-place.
+            #[inline]
+            pub fn insert(&mut self, other: $BitFlags) {
+                self.bits |= other.bits;
+            }
+
+            /// Removes the specified flags in-place.
+            #[inline]
+            pub fn remove(&mut self, other: $BitFlags) {
+                self.bits &= !other.bits;
+            }
+
+            /// Toggles the specified flags in-place.
+            #[inline]
+            pub fn toggle(&mut self, other: $BitFlags) {
+                self.bits ^= other.bits;
+            }
+
+            /// Inserts or removes the specified flags depending on the passed value.
+            #[inline]
+            pub fn set(&mut self, other: $BitFlags, value: bool) {
+                if value {
+                    self.insert(other);
+                } else {
+                    self.remove(other);
+                }
+            }
+        }
+
+        impl $crate::_core::ops::BitOr for $BitFlags {
+            type Output = $BitFlags;
+
+            /// Returns the union of the two sets of flags.
+            #[inline]
+            fn bitor(self, other: $BitFlags) -> $BitFlags {
+                $BitFlags { bits: self.bits | other.bits }
+            }
+        }
+
+        impl $crate::_core::ops::BitOrAssign for $BitFlags {
+
+            /// Adds the set of flags.
+            #[inline]
+            fn bitor_assign(&mut self, other: $BitFlags) {
+                self.bits |= other.bits;
+            }
+        }
+
+        impl $crate::_core::ops::BitXor for $BitFlags {
+            type Output = $BitFlags;
+
+            /// Returns the left flags, but with all the right flags toggled.
+            #[inline]
+            fn bitxor(self, other: $BitFlags) -> $BitFlags {
+                $BitFlags { bits: self.bits ^ other.bits }
+            }
+        }
+
+        impl $crate::_core::ops::BitXorAssign for $BitFlags {
+
+            /// Toggles the set of flags.
+            #[inline]
+            fn bitxor_assign(&mut self, other: $BitFlags) {
+                self.bits ^= other.bits;
+            }
+        }
+
+        impl $crate::_core::ops::BitAnd for $BitFlags {
+            type Output = $BitFlags;
+
+            /// Returns the intersection between the two sets of flags.
+            #[inline]
+            fn bitand(self, other: $BitFlags) -> $BitFlags {
+                $BitFlags { bits: self.bits & other.bits }
+            }
+        }
+
+        impl $crate::_core::ops::BitAndAssign for $BitFlags {
+
+            /// Disables all flags disabled in the set.
+            #[inline]
+            fn bitand_assign(&mut self, other: $BitFlags) {
+                self.bits &= other.bits;
+            }
+        }
+
+        impl $crate::_core::ops::Sub for $BitFlags {
+            type Output = $BitFlags;
+
+            /// Returns the set difference of the two sets of flags.
+            #[inline]
+            fn sub(self, other: $BitFlags) -> $BitFlags {
+                $BitFlags { bits: self.bits & !other.bits }
+            }
+        }
+
+        impl $crate::_core::ops::SubAssign for $BitFlags {
+
+            /// Disables all flags enabled in the set.
+            #[inline]
+            fn sub_assign(&mut self, other: $BitFlags) {
+                self.bits &= !other.bits;
+            }
+        }
+
+        impl $crate::_core::ops::Not for $BitFlags {
+            type Output = $BitFlags;
+
+            /// Returns the complement of this set of flags.
+            #[inline]
+            fn not(self) -> $BitFlags {
+                $BitFlags { bits: !self.bits } & $BitFlags::all()
+            }
+        }
+
+        impl $crate::_core::iter::Extend<$BitFlags> for $BitFlags {
+            fn extend<T: $crate::_core::iter::IntoIterator<Item=$BitFlags>>(&mut self, iterator: T) {
+                for item in iterator {
+                    self.insert(item)
+                }
+            }
+        }
+
+        impl $crate::_core::iter::FromIterator<$BitFlags> for $BitFlags {
+            fn from_iter<T: $crate::_core::iter::IntoIterator<Item=$BitFlags>>(iterator: T) -> $BitFlags {
+                let mut result = Self::empty();
+                result.extend(iterator);
+                result
+            }
+        }
+    };
+
+    // Every attribute that the user writes on a const is applied to the
+    // corresponding const that we generate, but within the implementation of
+    // Debug and all() we want to ignore everything but #[cfg] attributes. In
+    // particular, including a #[deprecated] attribute on those items would fail
+    // to compile.
+    // https://github.com/bitflags/bitflags/issues/109
+    //
+    // Input:
+    //
+    //     ? #[cfg(feature = "advanced")]
+    //     ? #[deprecated(note = "Use somthing else.")]
+    //     ? #[doc = r"High quality documentation."]
+    //     fn f() -> i32 { /* ... */ }
+    //
+    // Output:
+    //
+    //     #[cfg(feature = "advanced")]
+    //     fn f() -> i32 { /* ... */ }
+    (
+        $(#[$filtered:meta])*
+        ? #[cfg $($cfgargs:tt)*]
+        $(? #[$rest:ident $($restargs:tt)*])*
+        fn $($item:tt)*
+    ) => {
+        __impl_bitflags! {
+            $(#[$filtered])*
+            #[cfg $($cfgargs)*]
+            $(? #[$rest $($restargs)*])*
+            fn $($item)*
+        }
+    };
+    (
+        $(#[$filtered:meta])*
+        // $next != `cfg`
+        ? #[$next:ident $($nextargs:tt)*]
+        $(? #[$rest:ident $($restargs:tt)*])*
+        fn $($item:tt)*
+    ) => {
+        __impl_bitflags! {
+            $(#[$filtered])*
+            // $next filtered out
+            $(? #[$rest $($restargs)*])*
+            fn $($item)*
+        }
+    };
+    (
+        $(#[$filtered:meta])*
+        fn $($item:tt)*
+    ) => {
+        $(#[$filtered])*
+        fn $($item)*
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,17 +420,17 @@ macro_rules! __bitflags {
 #[cfg(bitflags_const_fn)]
 macro_rules! __fn_bitflags {
     (
-        $(#[$attr:ident $($attr_args:tt)*])*
+        $(# $attr_args:tt)*
         const fn $($item:tt)*
     ) => {
-        $(#[$attr $($attr_args)*])*
+        $(# $attr_args)*
         const fn $($item)*
     };
     (
-        $(#[$attr:ident $($attr_args:tt)*])*
+        $(# $attr_args:tt)*
         pub const fn $($item:tt)*
     ) => {
-        $(#[$attr $($attr_args)*])*
+        $(# $attr_args)*
         pub const fn $($item)*
     };
 }
@@ -440,17 +440,17 @@ macro_rules! __fn_bitflags {
 #[cfg(not(bitflags_const_fn))]
 macro_rules! __fn_bitflags {
     (
-        # $($attr_args:tt)*
+        $(# $attr_args:tt)*
         const fn $($item:tt)*
     ) => {
-        # $($attr_args)*
+        $(# $attr_args)*
         fn $($item)*
     };
     (
-        # $($attr_args:tt)*
+        $(# $attr_args:tt)*
         pub const fn $($item:tt)*
     ) => {
-        # $($attr_args)*
+        $(# $attr_args)*
         pub fn $($item)*
     };
 }


### PR DESCRIPTION
This adds const functions for every non mutable function in the crate.

It also adds a new join function so bitwise or of flags can be done as a const function as well

To avoid the crate from stop working with older versions of the compiler it detects the version using a build.rs script as advised in https://github.com/bitflags/bitflags/issues/170

Closes #170