### PR TITLE
Put the user-provided attributes first

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,8 +398,8 @@ macro_rules! __bitflags {
             )+
         }
     ) => {
-        #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
         $(#[$outer])*
+        #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
         $($vis)* struct $BitFlags {
             bits: $T,
         }


### PR DESCRIPTION

`#[derive]` should always come after any proc macro attribute.