### PR TITLE
Prepare for 1.0.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 1.0.5
+
+- Use compiletest_rs flags supported by stable toolchain ([#171])
+
+- Put the user provided attributes first ([#173])
+
+- Make bitflags methods `const` on newer compilers ([#175])
+
+[#171]: https://github.com/rust-lang-nursery/bitflags/pull/171
+[#173]: https://github.com/rust-lang-nursery/bitflags/pull/173
+[#175]: https://github.com/rust-lang-nursery/bitflags/pull/175
+
 # 1.0.4
 
 - Support Rust 2018 style macro imports ([#165])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "bitflags"
 # NB: When modifying, also modify:
 #   1. html_root_url in lib.rs
 #   2. number in readme (for breaking changes)
-version = "1.0.4"
+version = "1.0.5"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 keywords = ["bit", "bitmask", "bitflags", "flags"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@
 //! ```
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/bitflags/1.0.4")]
+#![doc(html_root_url = "https://docs.rs/bitflags/1.0.5")]
 
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
[Diff since the last release](https://github.com/bitflags/bitflags/compare/1.0.4...master)

Includes:

- #171 
- #173 
- #175 