### PR TITLE
Prepare for 1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.0
+
+This is a re-release of `1.0.5`, which was yanked due to a bug in the RLS.
+
 # 1.0.5
 
 - Use compiletest_rs flags supported by stable toolchain ([#171])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "bitflags"
 # NB: When modifying, also modify:
 #   1. html_root_url in lib.rs
 #   2. number in readme (for breaking changes)
-version = "1.0.5"
+version = "1.1.0"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 keywords = ["bit", "bitmask", "bitflags", "flags"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@
 //! ```
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/bitflags/1.0.5")]
+#![doc(html_root_url = "https://docs.rs/bitflags/1.1.0")]
 
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
Closes #178

Now that #177 has been solved upstream in `1.35.0`, we can republish the `bitflags` that includes support for constant functions.

I opted to make this `1.1.0` rather than `1.0.6` since it's possible folks are still using older compilers that will break, and `1.0.5` probably should've been `1.1.0` anyways, since it was just fixing bugs.