### PR TITLE
add from_bits_[ref|mut] for FFI in place ops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ travis-ci = { repository = "bitflags/bitflags" }
 
 [features]
 default = []
+unsafe = []
 example_generated = []
 
 [package.metadata.docs.rs]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -613,6 +613,7 @@ macro_rules! __impl_bitflags {
             /// A cheap reference-to-reference conversion.
             /// Used to convert from an existing bit representation,
             /// unless that representation contains bits that do not correspond to a flag.
+            #[cfg(feature = "unsafe")]
             #[inline]
             fn from_bits_ref(bits: &$T) -> Option<&$BitFlags> {
                 if (*bits & !$BitFlags::all().bits()) == 0 {
@@ -625,6 +626,7 @@ macro_rules! __impl_bitflags {
             /// A cheap, mutable reference-to-mutable reference conversion.
             /// Used to convert from an existing bit representation,
             /// unless that representation contains bits that do not correspond to a flag.
+            #[cfg(feature = "unsafe")]
             #[inline]
             fn from_bits_mut(bits: &mut $T) -> Option<&mut $BitFlags> {
                 if (*bits & !$BitFlags::all().bits()) == 0 {
@@ -1132,7 +1134,6 @@ mod tests {
         assert_eq!(m1, e1);
     }
 
-
     #[cfg(bitflags_const_fn)]
     #[test]
     fn test_const_fn() {
@@ -1376,6 +1377,7 @@ mod tests {
         assert_eq!(format!("{:?}", Flags::SOME), "SOME");
     }
 
+    #[cfg(feature = "unsafe")]
     #[test]
     fn test_from_bits_ref_or_mut() {
         bitflags! {


### PR DESCRIPTION
When use FFI struct, we always need to copy the field to a `flags` and write it back after change it
```rust
#[repr(C)]
struct Foo {
   bar: u32,
}

let mut flags = Flags::from_bits_truncate(foo.bar);
// ...
flags |= Flags::SOME;
// ...
foo.bar = flags.bits();
```
With `from_bits_ref` and `from_bits_mut` method, we could support in place operations, like
```rust
let flags = Flags::from_bits_mut(&mut foo.bar);
// ...
*flags |= Flags::SOME;
```
Every change to the underlying field could be read immediately,
and the mutable reference can be pass/return to other function, no more write back.
