### PR TITLE
fix up failing test and ensure it runs in CI

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -919,12 +919,12 @@ mod tests {
 
     bitflags! {
         struct _CfgFlags: u32 {
-            #[cfg(windows)]
-            const _CFG_A = 0b01;
             #[cfg(unix)]
-            const _CFG_B = 0b01;
+            const _CFG_A = 0b01;
             #[cfg(windows)]
-            const _CFG_C = _CFG_A.bits | 0b10;
+            const _CFG_B = 0b01;
+            #[cfg(unix)]
+            const _CFG_C = Self::_CFG_A.bits | 0b10;
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1111,7 +1111,7 @@ mod tests {
     #[cfg(bitflags_const_fn)]
     #[test]
     fn test_const_fn() {
-        const M1: Flags = Flags::empty();
+        const _M1: Flags = Flags::empty();
 
         const M2: Flags = Flags::A;
         assert_eq!(M2, Flags::A);


### PR DESCRIPTION
Closes #185 

We have a failing test on Windows that's been going unnoticed for a while, because we don't test Windows in CI.

This isn't a bug in `bitflags` itself, just one of its tests not being updated.