### PR TITLE
add #[repr(transparent)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,6 +418,7 @@ macro_rules! __bitflags {
         }
     ) => {
         $(#[$outer])*
+        #[repr(transparent)]
         #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
         $($vis)* struct $BitFlags {
             bits: $T,
@@ -588,7 +589,7 @@ macro_rules! __impl_bitflags {
                         )*
                     }
                 }
-            }            
+            }
 
             /// Returns the raw value of the flags currently stored.
             #[inline]
@@ -1018,12 +1019,12 @@ mod tests {
             unsafe { Flags::from_bits_unchecked(0b1001) },
             (extra | Flags::A)
         );
-      
+
         let extra = unsafe { EmptyFlags::from_bits_unchecked(0b1000) };
         assert_eq!(
-          unsafe { EmptyFlags::from_bits_unchecked(0b1000) },
-          (extra | EmptyFlags::empty())
-      );
+            unsafe { EmptyFlags::from_bits_unchecked(0b1000) },
+            (extra | EmptyFlags::empty())
+        );
     }
 
     #[test]
@@ -1286,10 +1287,7 @@ mod tests {
             "A | B | C | ABC | 0xb8"
         );
 
-        assert_eq!(
-          format!("{:?}", EmptyFlags::empty()),
-          "(empty)"
-      );
+        assert_eq!(format!("{:?}", EmptyFlags::empty()), "(empty)");
     }
 
     #[test]


### PR DESCRIPTION
add `#[repr(transparent)]` for the the FFI layout, replace #184.