### PR TITLE
Prepare for 1.2.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
     - rust: 1.20.0
       # This version don't support unstable features
       env: EXTRA_ARGS=""
+      script:
+        - cargo test
     - rust: stable
     - rust: stable
       os: osx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.2.0
+
+- Fix typo: {Lower, Upper}Exp - {Lower, Upper}Hex ([#183])
+
+- Add support for "unknown" bits ([#188])
+
+[#183]: https://github.com/rust-lang-nursery/bitflags/pull/183
+[#188]: https://github.com/rust-lang-nursery/bitflags/pull/188
+
 # 1.1.0
 
 This is a re-release of `1.0.5`, which was yanked due to a bug in the RLS.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "bitflags"
 # NB: When modifying, also modify:
 #   1. html_root_url in lib.rs
 #   2. number in readme (for breaking changes)
-version = "1.1.0"
+version = "1.2.0"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 keywords = ["bit", "bitmask", "bitflags", "flags"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,7 @@
 //! ```
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/bitflags/1.1.0")]
+#![doc(html_root_url = "https://docs.rs/bitflags/1.2.0")]
 
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
[Changes since the last release](https://github.com/bitflags/bitflags/compare/1.1.0...master)

I'll also use this PR to make sure our CI is in a good state.