### PR TITLE
Prepare for 1.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.2.1
+
+- Remove extraneous `#[inline]` attributes ([#194])
+
+[#194]: https://github.com/bitflags/bitflags/pull/194
+
 # 1.2.0
 
 - Fix typo: {Lower, Upper}Exp - {Lower, Upper}Hex ([#183])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "bitflags"
 # NB: When modifying, also modify:
 #   1. html_root_url in lib.rs
 #   2. number in readme (for breaking changes)
-version = "1.2.0"
+version = "1.2.1"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 keywords = ["bit", "bitmask", "bitflags", "flags"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,7 @@
 //! ```
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/bitflags/1.2.0")]
+#![doc(html_root_url = "https://docs.rs/bitflags/1.2.1")]
 
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
[Changes since the last release](https://github.com/bitflags/bitflags/compare/1.2.0...master)

This is necessary for https://github.com/rust-lang/rust/pull/65294 to be tested.