### PR TITLE
Use trybuild for compiletest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - LABEL="compiletest"
       script:
         - cargo test
-        - cargo test -p test_suite --features unstable
+        - cargo test -p test_suite
     - rust: stable
     - rust: stable
       os: osx

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -2,12 +2,9 @@
 name = "test_suite"
 version = "0.0.0"
 
-[features]
-unstable = ["compiletest_rs"]
-
 [dependencies]
 bitflags = { path = "../" }
-compiletest_rs = { version = "0.3.18", optional = true, features=["stable"] }
+trybuild = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/test_suite/tests/compile-fail/private_flags.rs
+++ b/test_suite/tests/compile-fail/private_flags.rs
@@ -16,5 +16,5 @@ mod example {
 
 fn main() {
     let flag1 = example::Flags1::FLAG_A;
-    let flag2 = example::Flags2::FLAG_B; //~ ERROR struct `Flags2` is private
+    let flag2 = example::Flags2::FLAG_B;
 }

--- a/test_suite/tests/compile-fail/private_flags.stderr
+++ b/test_suite/tests/compile-fail/private_flags.stderr
@@ -1,0 +1,5 @@
+error[E0603]: struct `Flags2` is private
+  --> $DIR/private_flags.rs:19:26
+   |
+19 |     let flag2 = example::Flags2::FLAG_B;
+   |                          ^^^^^^

--- a/test_suite/tests/compiletest.rs
+++ b/test_suite/tests/compiletest.rs
@@ -1,33 +1,5 @@
-#![cfg(feature = "unstable")]
-
-extern crate compiletest_rs as compiletest;
-
-use std::fs;
-use std::result::Result;
-
-use compiletest::common::Mode;
-
-fn run_mode(mode: Mode) {
-    let config = compiletest::Config {
-        mode: mode,
-        src_base: format!("tests/{}", mode).into(),
-        target_rustcflags: fs::read_dir("../target/debug/deps")
-            .unwrap()
-            .map(Result::unwrap)
-            .filter(|entry| {
-                let file_name = entry.file_name();
-                let file_name = file_name.to_string_lossy();
-                file_name.starts_with("libbitflags-") && file_name.ends_with(".rlib")
-            })
-            .max_by_key(|entry| entry.metadata().unwrap().modified().unwrap())
-            .map(|entry| format!("--extern bitflags={}", entry.path().to_string_lossy())),
-        ..Default::default()
-    };
-
-    compiletest::run_tests(&config);
-}
-
 #[test]
-fn compile_test() {
-    run_mode(Mode::CompileFail);
+fn compile_fail() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile-fail/*.rs");
 }


### PR DESCRIPTION
Closes #193.

Replaces [compiletest](https://github.com/laumann/compiletest-rs) with [trybuild](https://github.com/dtolnay/trybuild) for compile tests. Also, empty smoke-tests without asserts can use `trybuild` in `compile_pass` mode too.
