### PR TITLE
End `empty` doc comment with full stop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -575,7 +575,7 @@ macro_rules! __impl_bitflags {
             )+
 
             __fn_bitflags! {
-                /// Returns an empty set of flags
+                /// Returns an empty set of flags.
                 #[inline]
                 pub const fn empty() -> $BitFlags {
                     $BitFlags { bits: 0 }


### PR DESCRIPTION
Trivial: `empty` is the only function whose generated API doc doesn’t end with a full stop. Let’s add one.