### PR TITLE
Implement Iterator for bitflags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -818,6 +818,13 @@ macro_rules! __impl_bitflags {
                 }
             }
         }
+
+        impl $crate::_core::iter::ExactSizeIterator for $BitFlags {
+            // We can easily calculate the remaining number of iterations.
+            fn len(&self) -> usize {
+                self.bits.count_ones()
+            }
+        }
     };
 
     // Every attribute that the user writes on a const is applied to the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1446,4 +1446,33 @@ mod tests {
         assert_eq!(format!("{:?}", Flags::empty()), "NONE");
         assert_eq!(format!("{:?}", Flags::SOME), "SOME");
     }
+
+    #[test]
+    fn test_iter() {
+        bitflags! {
+            struct Flags: u32 {
+                const ONE  = 0b001;
+                const TWO  = 0b010;
+                const THREE = 0b100;
+            }
+        }
+
+        let mut flags = Flags::all();
+        assert_eq!(flags.count(), 3);
+        assert_eq!(flags.next().unwrap(), Flags::ONE);
+        assert_eq!(flags.next().unwrap(), Flags::TWO);
+        assert_eq!(flags.next().unwrap(), Flags::THREE);
+        assert_eq!(flags.next(), None);
+        assert_eq!(flags.count(), 0);
+
+        let flags = Flags::empty();
+        assert_eq!(flags.count(), 0);
+
+        let mut flags = Flags::ONE | Flags::THREE;
+        assert_eq!(flags.count(), 2);
+        assert_eq!(flags.next().unwrap(), Flags::ONE);
+        assert_eq!(flags.next().unwrap(), Flags::THREE);
+        assert_eq!(flags.next(), None);
+        assert_eq!(flags.count(), 0);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -820,7 +820,6 @@ macro_rules! __impl_bitflags {
         }
 
         impl $crate::_core::iter::ExactSizeIterator for $BitFlags {
-            // We can easily calculate the remaining number of iterations.
             fn len(&self) -> usize {
                 self.bits.count_ones()
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -805,6 +805,19 @@ macro_rules! __impl_bitflags {
                 result
             }
         }
+
+        impl $crate::_core::iter::Iterator for $BitFlags {
+            type Item = $BitFlags;
+            fn next(&mut self) -> Option<$BitFlags> {
+                if self.is_empty() {
+                    None
+                }else{
+                    let r = unsafe{ Self::from_bits_unchecked(1 << self.bits.trailing_zeros()) };
+                    self.remove(r);
+                    Some(r)
+                }
+            }
+        }
     };
 
     // Every attribute that the user writes on a const is applied to the


### PR DESCRIPTION
Allows to use a bitflags type as an iterator, iterating through all the enabled flags and consuming the original in the process.

This implements `Iterator` using `trailing_zeros` and also `ExactSizeIterator` using count_ones.