### PR TITLE
Making crate accessible from std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,17 @@ exclude = [
 ]
 build = "build.rs"
 
+[dependencies]
+core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
+compiler_builtins = { version = '0.1.2', optional = true }
+
 [badges]
 travis-ci = { repository = "bitflags/bitflags" }
 
 [features]
 default = []
 example_generated = []
+rustc-dep-of-std = ["core", "compiler_builtins"]
 
 [package.metadata.docs.rs]
 features = [ "example_generated" ]

--- a/test_suite/tests/compile-fail/private_flags.stderr
+++ b/test_suite/tests/compile-fail/private_flags.stderr
@@ -2,4 +2,15 @@ error[E0603]: struct `Flags2` is private
   --> $DIR/private_flags.rs:19:26
    |
 19 |     let flag2 = example::Flags2::FLAG_B;
-   |                          ^^^^^^
+   |                          ^^^^^^ private struct
+   |
+note: the struct `Flags2` is defined here
+  --> $DIR/private_flags.rs:10:5
+   |
+10 | /     bitflags! {
+11 | |         struct Flags2: u32 {
+12 | |             const FLAG_B = 0b00000010;
+13 | |         }
+14 | |     }
+   | |_____^
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Changing dependencies to enable the crate to be used from inside the rust standard library.

see https://github.com/rust-lang/rust/tree/master/library/rustc-std-workspace-core

cc: @jethrogb