### PR TITLE
Make from_bits a const fn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -617,7 +617,7 @@ macro_rules! __impl_bitflags {
             /// Convert from underlying bit representation, unless that
             /// representation contains bits that do not correspond to a flag.
             #[inline]
-            pub fn from_bits(bits: $T) -> $crate::_core::option::Option<$BitFlags> {
+            pub const fn from_bits(bits: $T) -> $crate::_core::option::Option<$BitFlags> {
                 if (bits & !$BitFlags::all().bits()) == 0 {
                     $crate::_core::option::Option::Some($BitFlags { bits })
                 } else {


### PR DESCRIPTION
'if' now works in 'const fn as of rust 1.4.6 (https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html).

I would love to have 'from_bits' be a 'const fn' because it is the safest from_* function.