### PR TITLE
Remove remaining mentions of Travis CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ description = """
 A macro to generate structures which behave like bitflags.
 """
 exclude = [
-    ".travis.yml",
     "appveyor.yml",
     "bors.toml"
 ]
@@ -26,9 +25,6 @@ build = "build.rs"
 [dependencies]
 core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
 compiler_builtins = { version = '0.1.2', optional = true }
-
-[badges]
-travis-ci = { repository = "bitflags/bitflags" }
 
 [features]
 default = []

--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,3 @@
 status = [
-	"continuous-integration/travis-ci/push",
+	"rust",
 ]


### PR DESCRIPTION
Disclaimer: I have no idea what am I doing!

![image](https://user-images.githubusercontent.com/6737986/117577837-22f62e80-b0f4-11eb-9b01-e9bf83d7e825.png)

***

Badges section has been removed from crates.io; it is suggested to place
them in README instead[1], which we already have done.

In bors.toml, the status section. Its is unclear from the docs[2], what those
strings are. But it seems to me, they should reference name of GitHub
Workflow file with CI pipelines[3].

[1]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section
[2]: https://bors.tech/documentation/
[3]: https://bors.tech/devdocs/bors-ng/readme.html