### PR TITLE
Fixex compilation for rustc 1.32 or less

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,8 +13,8 @@ fn main() {
         println!("cargo:rustc-cfg=bitflags_const_fn");
     }
 
-    // const fn conditionals stabilized in Rust 1.32:
-    if minor >= 32 {
+    // const fn conditionals stabilized in Rust 1.33:
+    if minor >= 33 {
         println!("cargo:rustc-cfg=bitflags_const_fn_cond");
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,11 @@ fn main() {
     if minor >= 31 {
         println!("cargo:rustc-cfg=bitflags_const_fn");
     }
+
+    // const fn conditionals stabilized in Rust 1.32:
+    if minor >= 32 {
+        println!("cargo:rustc-cfg=bitflags_const_fn_cond");
+    }
 }
 
 fn rustc_minor_version() -> Option<u32> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,6 +490,60 @@ macro_rules! __fn_bitflags {
 
 #[macro_export(local_inner_macros)]
 #[doc(hidden)]
+#[cfg(bitflags_const_fn_cond)]
+macro_rules! __fn_bitflags_cond {
+    (
+        $(# $attr_args:tt)*
+        const fn $($item:tt)*
+    ) => {
+        $(# $attr_args)*
+        const fn $($item)*
+    };
+    (
+        $(# $attr_args:tt)*
+        pub const fn $($item:tt)*
+    ) => {
+        $(# $attr_args)*
+        pub const fn $($item)*
+    };
+    (
+        $(# $attr_args:tt)*
+        pub const unsafe fn $($item:tt)*
+    ) => {
+        $(# $attr_args)*
+        pub const unsafe fn $($item)*
+    };
+}
+
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+#[cfg(not(bitflags_const_fn_cond))]
+macro_rules! __fn_bitflags_cond {
+    (
+        $(# $attr_args:tt)*
+        const fn $($item:tt)*
+    ) => {
+        $(# $attr_args)*
+        fn $($item)*
+    };
+    (
+        $(# $attr_args:tt)*
+        pub const fn $($item:tt)*
+    ) => {
+        $(# $attr_args)*
+        pub fn $($item)*
+    };
+    (
+        $(# $attr_args:tt)*
+        pub const unsafe fn $($item:tt)*
+    ) => {
+        $(# $attr_args)*
+        pub unsafe fn $($item)*
+    };
+}
+
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
 macro_rules! __all_bitflags {
     (
         $BitFlags:ident: $T:ty {
@@ -663,7 +717,7 @@ macro_rules! __impl_bitflags {
                 }
             }
 
-            __fn_bitflags! {
+            __fn_bitflags_cond! {
                 /// Convert from underlying bit representation, unless that
                 /// representation contains bits that do not correspond to a flag.
                 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -663,14 +663,16 @@ macro_rules! __impl_bitflags {
                 }
             }
 
-            /// Convert from underlying bit representation, unless that
-            /// representation contains bits that do not correspond to a flag.
-            #[inline]
-            pub const fn from_bits(bits: $T) -> $crate::_core::option::Option<$BitFlags> {
-                if (bits & !$BitFlags::all().bits()) == 0 {
-                    $crate::_core::option::Option::Some($BitFlags { bits })
-                } else {
-                    $crate::_core::option::Option::None
+            __fn_bitflags! {
+                /// Convert from underlying bit representation, unless that
+                /// representation contains bits that do not correspond to a flag.
+                #[inline]
+                pub const fn from_bits(bits: $T) -> $crate::_core::option::Option<$BitFlags> {
+                    if (bits & !$BitFlags::all().bits()) == 0 {
+                        $crate::_core::option::Option::Some($BitFlags { bits })
+                    } else {
+                        $crate::_core::option::Option::None
+                    }
                 }
             }
 
@@ -1097,7 +1099,7 @@ mod tests {
             unsafe { Flags::from_bits_unchecked(0b1001) },
             (extra | Flags::A)
         );
-      
+
         let extra = unsafe { EmptyFlags::from_bits_unchecked(0b1000) };
         assert_eq!(
           unsafe { EmptyFlags::from_bits_unchecked(0b1000) },


### PR DESCRIPTION
The function `from_bits` was declared as const but not wrapped in the `__bitflags_fn` macro. The `__bitflags_fn` turns const into non const functions for rustc 1.31 or higher but this function contains conditionals which aren't supported until 1.33

This PR adds a new macro and cfg flag in build.rs which turns anything wrapped in `__bitflags_fn_cond` from const to non const fn if the rustc version is 1.32 or less.