### PR TITLE
Add an "impl_arbitrary" feature to enable implementing `Arbitrary`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,13 @@ walkdir = "2.3"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+arbitrary = "1"
 
 [features]
 default = []
 example_generated = []
 rustc-dep-of-std = ["core", "compiler_builtins"]
+impl_arbitrary = []
 
 [package.metadata.docs.rs]
 features = ["example_generated"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -820,6 +820,8 @@ macro_rules! __impl_bitflags {
                 result
             }
         }
+
+        __impl_arbitrary_for_bitflags!($BitFlags);
     };
 
     // Every attribute that the user writes on a const is applied to the
@@ -929,6 +931,28 @@ macro_rules! __impl_bitflags {
         $(#[$filtered])*
         const $($item)*
     };
+}
+
+// When "arbitrary" is not enabled, emit code to implement the `Arbitrary` trait.
+#[cfg(feature = "impl_arbitrary")]
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! __impl_arbitrary_for_bitflags {
+    ($BitFlags:ident) => {
+        impl<'a> arbitrary::Arbitrary<'a> for $BitFlags {
+            fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+                 Self::from_bits(u.arbitrary()?).ok_or_else(|| arbitrary::Error::IncorrectFormat)
+            }
+        }
+    };
+}
+
+// When "arbitrary" is not enabled, don't emit any code for it.
+#[cfg(not(feature = "impl_arbitrary"))]
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! __impl_arbitrary_for_bitflags {
+    ($BitFlags:ident) => {};
 }
 
 #[cfg(feature = "example_generated")]

--- a/tests/arbitrary.rs
+++ b/tests/arbitrary.rs
@@ -1,0 +1,17 @@
+#![cfg(feature = "impl_arbitrary")]
+
+use arbitrary::Arbitrary;
+
+bitflags::bitflags! {
+    struct Color: u32 {
+        const RED = 0x1;
+        const GREEN = 0x2;
+        const BLUE = 0x4;
+    }
+}
+
+#[test]
+fn test_arbitary() {
+    let mut unstructured = arbitrary::Unstructured::new(&[0_u8; 256]);
+    let _color = Color::arbitrary(&mut unstructured);
+}


### PR DESCRIPTION
Fixes #248.