### PR TITLE
Add example to the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,33 @@ and this to your source code:
 use bitflags::bitflags;
 ```
 
+## Example
+
+Generate a flags structure:
+
+```rust
+use bitflags::bitflags;
+
+// The `bitflags!` macro generates `struct`s that manage a set of flags.
+bitflags! {
+    struct Flags: u32 {
+        const A = 0b00000001;
+        const B = 0b00000010;
+        const C = 0b00000100;
+        const ABC = Self::A.bits | Self::B.bits | Self::C.bits;
+    }
+}
+
+fn main() {
+    let e1 = Flags::A | Flags::C;
+    let e2 = Flags::B | Flags::C;
+    assert_eq!((e1 | e2), Flags::ABC);   // union
+    assert_eq!((e1 & e2), Flags::C);     // intersection
+    assert_eq!((e1 - e2), Flags::A);     // set difference
+    assert_eq!(!e2, Flags::A);           // set complement
+}
+```
+
 ## Rust Version Support
 
 The minimum supported Rust version is 1.46 due to use of associated constants and const functions.


### PR DESCRIPTION
Add a simple example to the README.md file to show the capabilities of the crate.  The README is displayed in many places where developers are evaluating its use and having an example is always useful.