### PR TITLE
from_bits_(truncate) fail with composite flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1820,8 +1820,6 @@ mod tests {
             const D = 8;
         }
     }
-}
-
 
     #[test]
     fn test_from_bits_edge_cases() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1812,7 +1812,7 @@ mod tests {
     }
 
     bitflags! {
-        #[derive(serde::Serialize, serde::Deserialize)]
+        #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
         struct SerdeFlags: u32 {
             const A = 1;
             const B = 2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -559,19 +559,12 @@ macro_rules! __impl_bitflags {
             /// representation contains bits that do not correspond to a flag.
             #[inline]
             pub const fn from_bits(bits: $T) -> $crate::_core::option::Option<Self> {
-                if bits == 0 {
-                    return Some(Self{ bits })
+                let truncated = Self::from_bits_truncate(bits).bits;
+                if truncated == bits {
+                    Some(Self{ bits })
+                } else {
+                    None
                 }
-
-                $(
-                    #[allow(unused_doc_comments, unused_attributes)]
-                    $(#[$attr $($args)*])*
-                    if bits & Self::$Flag.bits == Self::$Flag.bits {
-                        return Some(Self{ bits })
-                    }
-                )*
-
-                None
             }
 
             /// Convert from underlying bit representation, dropping any bits
@@ -1832,7 +1825,9 @@ mod tests {
 
 
         let flags = Flags::from_bits(0b00000100);
-        assert!(flags.is_none());
+        assert_eq!(flags, None);
+        let flags = Flags::from_bits(0b00000101);
+        assert_eq!(flags, None);
     }
 
     #[test]
@@ -1846,6 +1841,8 @@ mod tests {
 
 
         let flags = Flags::from_bits_truncate(0b00000100);
-        assert!(flags.is_empty());
+        assert_eq!(flags, Flags::empty());
+        let flags = Flags::from_bits_truncate(0b00000101);
+        assert_eq!(flags, Flags::A);
     }
 }

--- a/tests/compile-fail/non_integer_base/all_defined.stderr.beta
+++ b/tests/compile-fail/non_integer_base/all_defined.stderr.beta
@@ -49,25 +49,7 @@ error[E0308]: mismatched types
     = note: this error originates in the macro `__impl_bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: try wrapping the expression in `MyInt`
     |
-562 |                 if bits == MyInt(0) {
-    |                            ++++++ +
-
-error[E0308]: mismatched types
-   --> $DIR/all_defined.rs:115:1
-    |
-115 | / bitflags! {
-116 | |     struct Flags128: MyInt {
-117 | |         const A = MyInt(0b0000_0001u8);
-118 | |         const B = MyInt(0b0000_0010u8);
-119 | |         const C = MyInt(0b0000_0100u8);
-120 | |     }
-121 | | }
-    | |_^ expected struct `MyInt`, found integer
-    |
-    = note: this error originates in the macro `__impl_bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: try wrapping the expression in `MyInt`
-    |
-581 |                 if bits == MyInt(0) {
+574 |                 if bits == MyInt(0) {
     |                            ++++++ +
 
 error[E0277]: no implementation for `{integer} |= MyInt`
@@ -100,7 +82,7 @@ error[E0308]: mismatched types
     = note: this error originates in the macro `__impl_bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: try wrapping the expression in `MyInt`
     |
-596 |                 Self { bits: MyInt(truncated) }
+589 |                 Self { bits: MyInt(truncated) }
     |                              ++++++         +
 
 error[E0308]: mismatched types

--- a/tests/compile-fail/non_integer_base/all_defined.stderr.beta
+++ b/tests/compile-fail/non_integer_base/all_defined.stderr.beta
@@ -49,8 +49,59 @@ error[E0308]: mismatched types
     = note: this error originates in the macro `__impl_bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: try wrapping the expression in `MyInt`
     |
-562 |                 if (bits & !Self::all().bits()) == MyInt(0) {
-    |                                                    ++++++ +
+562 |                 if bits == MyInt(0) {
+    |                            ++++++ +
+
+error[E0308]: mismatched types
+   --> $DIR/all_defined.rs:115:1
+    |
+115 | / bitflags! {
+116 | |     struct Flags128: MyInt {
+117 | |         const A = MyInt(0b0000_0001u8);
+118 | |         const B = MyInt(0b0000_0010u8);
+119 | |         const C = MyInt(0b0000_0100u8);
+120 | |     }
+121 | | }
+    | |_^ expected struct `MyInt`, found integer
+    |
+    = note: this error originates in the macro `__impl_bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: try wrapping the expression in `MyInt`
+    |
+581 |                 if bits == MyInt(0) {
+    |                            ++++++ +
+
+error[E0277]: no implementation for `{integer} |= MyInt`
+   --> $DIR/all_defined.rs:115:1
+    |
+115 | / bitflags! {
+116 | |     struct Flags128: MyInt {
+117 | |         const A = MyInt(0b0000_0001u8);
+118 | |         const B = MyInt(0b0000_0010u8);
+119 | |         const C = MyInt(0b0000_0100u8);
+120 | |     }
+121 | | }
+    | |_^ no implementation for `{integer} |= MyInt`
+    |
+    = help: the trait `BitOrAssign<MyInt>` is not implemented for `{integer}`
+    = note: this error originates in the macro `__impl_bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+   --> $DIR/all_defined.rs:115:1
+    |
+115 | / bitflags! {
+116 | |     struct Flags128: MyInt {
+117 | |         const A = MyInt(0b0000_0001u8);
+118 | |         const B = MyInt(0b0000_0010u8);
+119 | |         const C = MyInt(0b0000_0100u8);
+120 | |     }
+121 | | }
+    | |_^ expected struct `MyInt`, found integer
+    |
+    = note: this error originates in the macro `__impl_bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: try wrapping the expression in `MyInt`
+    |
+596 |                 Self { bits: MyInt(truncated) }
+    |                              ++++++         +
 
 error[E0308]: mismatched types
    --> $DIR/all_defined.rs:115:1


### PR DESCRIPTION
When a bitflags type contains composite flags like:

```rs
bitflags! {
    struct Flags: u8 {
            const A = 0b00000001;
            const BC = 0b00000110;
    }
}
```

from_bits and from_bits_truncate would not work as expected allowing flags that are not declared.

Fixes #275