### PR TITLE
serde tests fail in CI

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1789,7 +1789,7 @@ mod tests {
     }
 
     bitflags! {
-        #[derive(serde::Serialize, serde::Deserialize)]
+        #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
         struct SerdeFlags: u32 {
             const A = 1;
             const B = 2;


### PR DESCRIPTION
Cause Serialize and Deserialize derives are used from serde:: instead of serde_derive::