### PR TITLE
Iterator over all the enabled options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -759,8 +759,7 @@ macro_rules! __impl_bitflags {
                     if self.is_empty() || NUM_FLAGS == 0 {
                         None
                     }else{
-                        for pos in start..NUM_FLAGS {
-                            let flag = OPTIONS[pos];
+                        for flag in OPTIONS[start..NUM_FLAGS].iter().copied() {
                             start += 1;
                             if self.contains(flag) {
                                 self.remove(flag);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -730,6 +730,50 @@ macro_rules! __impl_bitflags {
                 Self::from_bits_truncate(!self.bits)
             }
 
+            /// Returns an iterator over all the flags in this set.
+            pub fn iter(mut self) -> impl Iterator<Item = Self> {
+                let mut options = [
+                    $(
+                        #[allow(unused_doc_comments, unused_attributes)]
+                        $(#[$attr $($args)*])*
+                        Self::$Flag,
+                    )*
+                ];
+                const NUM_FLAGS: usize = {
+                    #[allow(unused_mut)]
+                    let mut num_flags = 0;
+
+                    $(
+                        #[allow(unused_doc_comments, unused_attributes)]
+                        $(#[$attr $($args)*])*
+                        {
+                            num_flags += 1;
+                        }
+                    )*
+
+                    num_flags
+                };
+                let mut len = NUM_FLAGS;
+
+                $crate::_core::iter::from_fn(move || {
+                    if self.is_empty() || NUM_FLAGS == 0 || len == 0 {
+                        None
+                    }else{
+                        for pos in 0..len {
+                            let flag = options[pos];
+                            len -= 1;
+                            options.swap(pos, len);
+                            if self.contains(flag) {
+                                self.remove(flag);
+                                return Some(flag)
+                            }
+                        }
+
+                        None
+                    }
+                })
+            }
+
         }
 
         impl $crate::_core::ops::BitOr for $BitFlags {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -732,7 +732,7 @@ macro_rules! __impl_bitflags {
 
             /// Returns an iterator over all the flags in this set.
             pub fn iter(mut self) -> impl Iterator<Item = Self> {
-                let mut options = [
+                let options = [
                     $(
                         #[allow(unused_doc_comments, unused_attributes)]
                         $(#[$attr $($args)*])*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -756,7 +756,7 @@ macro_rules! __impl_bitflags {
                 let mut start = 0;
 
                 $crate::_core::iter::from_fn(move || {
-                    if self.is_empty() || NUM_FLAGS == 0 || start == NUM_FLAGS {
+                    if self.is_empty() || NUM_FLAGS == 0 {
                         None
                     }else{
                         for pos in start..NUM_FLAGS {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -753,16 +753,15 @@ macro_rules! __impl_bitflags {
 
                     num_flags
                 };
-                let mut len = NUM_FLAGS;
+                let mut start = 0;
 
                 $crate::_core::iter::from_fn(move || {
-                    if self.is_empty() || NUM_FLAGS == 0 || len == 0 {
+                    if self.is_empty() || NUM_FLAGS == 0 || start == NUM_FLAGS {
                         None
                     }else{
-                        for pos in 0..len {
+                        for pos in start..NUM_FLAGS {
                             let flag = options[pos];
-                            len -= 1;
-                            options.swap(pos, len);
+                            start += 1;
                             if self.contains(flag) {
                                 self.remove(flag);
                                 return Some(flag)
@@ -1856,8 +1855,8 @@ mod tests {
         assert_eq!(flags.iter().count(), 3);
         let mut iter = flags.iter();
         assert_eq!(iter.next().unwrap(), Flags::ONE);
-        assert_eq!(iter.next().unwrap(), Flags::THREE);
         assert_eq!(iter.next().unwrap(), Flags::TWO);
+        assert_eq!(iter.next().unwrap(), Flags::THREE);
         assert_eq!(iter.next(), None);
 
         let flags = Flags::empty();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -732,13 +732,6 @@ macro_rules! __impl_bitflags {
 
             /// Returns an iterator over all the flags in this set.
             pub fn iter(mut self) -> impl Iterator<Item = Self> {
-                let options = [
-                    $(
-                        #[allow(unused_doc_comments, unused_attributes)]
-                        $(#[$attr $($args)*])*
-                        Self::$Flag,
-                    )*
-                ];
                 const NUM_FLAGS: usize = {
                     #[allow(unused_mut)]
                     let mut num_flags = 0;
@@ -753,6 +746,13 @@ macro_rules! __impl_bitflags {
 
                     num_flags
                 };
+                const OPTIONS: [$BitFlags; NUM_FLAGS] = [
+                    $(
+                        #[allow(unused_doc_comments, unused_attributes)]
+                        $(#[$attr $($args)*])*
+                        $BitFlags::$Flag,
+                    )*
+                ];
                 let mut start = 0;
 
                 $crate::_core::iter::from_fn(move || {
@@ -760,7 +760,7 @@ macro_rules! __impl_bitflags {
                         None
                     }else{
                         for pos in start..NUM_FLAGS {
-                            let flag = options[pos];
+                            let flag = OPTIONS[pos];
                             start += 1;
                             if self.contains(flag) {
                                 self.remove(flag);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1841,4 +1841,51 @@ mod tests {
             const D = 8;
         }
     }
+
+    #[test]
+    fn test_iter() {
+        bitflags! {
+            struct Flags: u32 {
+                const ONE  = 0b001;
+                const TWO  = 0b010;
+                const THREE = 0b100;
+            }
+        }
+
+        let flags = Flags::all();
+        assert_eq!(flags.iter().count(), 3);
+        let mut iter = flags.iter();
+        assert_eq!(iter.next().unwrap(), Flags::ONE);
+        assert_eq!(iter.next().unwrap(), Flags::THREE);
+        assert_eq!(iter.next().unwrap(), Flags::TWO);
+        assert_eq!(iter.next(), None);
+
+        let flags = Flags::empty();
+        assert_eq!(flags.iter().count(), 0);
+
+        let flags = Flags::ONE | Flags::THREE;
+        assert_eq!(flags.iter().count(), 2);
+        let mut iter = flags.iter();
+        assert_eq!(iter.next().unwrap(), Flags::ONE);
+        assert_eq!(iter.next().unwrap(), Flags::THREE);
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_iter_edge_cases() {
+        bitflags! {
+            struct Flags: u8 {
+                const A = 0b00000001;
+                const BC = 0b00000110;
+            }
+        }
+
+
+        let flags = Flags::all();
+        assert_eq!(flags.iter().count(), 2);
+        let mut iter = flags.iter();
+        assert_eq!(iter.next().unwrap(), Flags::A);
+        assert_eq!(iter.next().unwrap(), Flags::BC);
+        assert_eq!(iter.next(), None);
+    }
 }


### PR DESCRIPTION
Adds a new function that returns an iterator over all the enabled flags.

This implementation takes into account combined flags like the ones described in: https://github.com/bitflags/bitflags/pull/204#issuecomment-950304444

It uses an `impl Iterator` as return type because using an specific Iter type implies using const generics which are not supported in earlier versions of rust and adding a const to the trait in order to express the correct dimension of the array as can be seen in the last solution proposed in #204.

Superseeds #204