### PR TITLE
Support creating flags from their names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1381,22 +1381,22 @@ mod tests {
             assert!(flags.contains(flag));
         }
 
-        let mut iter = flags.iter_raw();
+        let mut iter = flags.iter_names();
 
-        assert_eq!(iter.next().unwrap(), ("ONE", Flags::ONE.bits()));
-        assert_eq!(iter.next().unwrap(), ("TWO", Flags::TWO.bits()));
-        assert_eq!(iter.next().unwrap(), ("THREE", Flags::THREE.bits()));
+        assert_eq!(iter.next().unwrap(), ("ONE", Flags::ONE));
+        assert_eq!(iter.next().unwrap(), ("TWO", Flags::TWO));
+        assert_eq!(iter.next().unwrap(), ("THREE", Flags::THREE));
 
         #[cfg(unix)]
         {
-            assert_eq!(iter.next().unwrap(), ("FOUR_UNIX", Flags::FOUR_UNIX.bits()));
+            assert_eq!(iter.next().unwrap(), ("FOUR_UNIX", Flags::FOUR_UNIX));
         }
         #[cfg(windows)]
         {
-            assert_eq!(iter.next().unwrap(), ("FOUR_WIN", Flags::FOUR_WIN.bits()));
+            assert_eq!(iter.next().unwrap(), ("FOUR_WIN", Flags::FOUR_WIN));
         }
 
-        assert_eq!(iter.next().unwrap(), ("FIVE", Flags::FIVE.bits()));
+        assert_eq!(iter.next().unwrap(), ("FIVE", Flags::FIVE));
 
         assert_eq!(iter.next(), None);
 
@@ -1406,10 +1406,25 @@ mod tests {
         let flags = Flags::ONE | Flags::THREE;
         assert_eq!(flags.into_iter().count(), 2);
 
-        let mut iter = flags.iter_raw();
+        let mut iter = flags.iter_names();
 
-        assert_eq!(iter.next().unwrap(), ("ONE", Flags::ONE.bits()));
-        assert_eq!(iter.next().unwrap(), ("THREE", Flags::THREE.bits()));
+        assert_eq!(iter.next().unwrap(), ("ONE", Flags::ONE));
+        assert_eq!(iter.next().unwrap(), ("THREE", Flags::THREE));
         assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_from_name() {
+        let flags = Flags::all();
+
+        let mut rebuilt = Flags::empty();
+
+        for (name, value) in flags.iter_names() {
+            assert_eq!(value, Flags::from_name(name).unwrap());
+
+            rebuilt |= Flags::from_name(name).unwrap();
+        }
+
+        assert_eq!(flags, rebuilt);
     }
 }

--- a/src/public.rs
+++ b/src/public.rs
@@ -26,7 +26,7 @@ macro_rules! __declare_public_bitflags {
 #[doc(hidden)]
 macro_rules! __impl_public_bitflags {
     (
-        $PublicBitFlags:ident: $T:ty, $InternalBitFlags:ident, $Iter:ident, $IterRaw:ident {
+        $PublicBitFlags:ident: $T:ty, $InternalBitFlags:ident, $Iter:ident, $IterNames:ident {
             $(
                 $(#[$attr:ident $($args:tt)*])*
                 $Flag:ident = $value:expr;
@@ -100,18 +100,21 @@ macro_rules! __impl_public_bitflags {
 
             /// Convert from underlying bit representation, preserving all
             /// bits (even those not corresponding to a defined flag).
-            ///
-            /// # Safety
-            ///
-            /// The caller of the `bitflags!` macro can choose to allow or
-            /// disallow extra bits for their bitflags type.
-            ///
-            /// The caller of `from_bits_retain()` has to ensure that
-            /// all bits correspond to a defined flag or that extra bits
-            /// are valid for this bitflags type.
             #[inline]
             pub const fn from_bits_retain(bits: $T) -> Self {
                 Self($InternalBitFlags::from_bits_retain(bits))
+            }
+
+            /// Get the value for a flag from its stringified name.
+            ///
+            /// Names are _case-sensitive_, so must correspond exactly to
+            /// the identifier given to the flag.
+            #[inline]
+            pub fn from_name(name: &str) -> $crate::__private::core::option::Option<Self> {
+                match $InternalBitFlags::from_name(name) {
+                    $crate::__private::core::option::Option::Some(bits) => $crate::__private::core::option::Option::Some(Self(bits)),
+                    $crate::__private::core::option::Option::None => $crate::__private::core::option::Option::None,
+                }
             }
 
             /// Iterate over enabled flag values.
@@ -120,10 +123,10 @@ macro_rules! __impl_public_bitflags {
                 self.0.iter()
             }
 
-            /// Iterate over the raw names and bits for enabled flag values.
+            /// Iterate over enabled flag values with their stringified names.
             #[inline]
-            pub const fn iter_raw(&self) -> $IterRaw {
-                self.0.iter_raw()
+            pub const fn iter_names(&self) -> $IterNames {
+                self.0.iter_names()
             }
 
             /// Returns `true` if no flags are currently stored.
@@ -377,7 +380,7 @@ macro_rules! __impl_public_bitflags {
             type Bits = $T;
 
             type Iter = $Iter;
-            type IterRaw = $IterRaw;
+            type IterNames = $IterNames;
 
             fn empty() -> Self {
                 $PublicBitFlags::empty()
@@ -403,12 +406,16 @@ macro_rules! __impl_public_bitflags {
                 $PublicBitFlags::from_bits_retain(bits)
             }
 
+            fn from_name(name: &str) -> $crate::__private::core::option::Option<$PublicBitFlags> {
+                $PublicBitFlags::from_name(name)
+            }
+
             fn iter(&self) -> Self::Iter {
                 $PublicBitFlags::iter(self)
             }
 
-            fn iter_raw(&self) -> Self::IterRaw {
-                $PublicBitFlags::iter_raw(self)
+            fn iter_names(&self) -> Self::IterNames {
+                $PublicBitFlags::iter_names(self)
             }
 
             fn is_empty(&self) -> bool {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -11,7 +11,7 @@ pub trait BitFlags: ImplementedByBitFlagsMacro {
     type Iter: Iterator<Item = Self>;
 
     /// An iterator over the raw names and bits for enabled flags in an instance of the type.
-    type IterRaw: Iterator<Item = (&'static str, Self::Bits)>;
+    type IterNames: Iterator<Item = (&'static str, Self)>;
 
     /// Returns an empty set of flags.
     fn empty() -> Self;
@@ -36,11 +36,16 @@ pub trait BitFlags: ImplementedByBitFlagsMacro {
     /// bits (even those not corresponding to a defined flag).
     fn from_bits_retain(bits: Self::Bits) -> Self;
 
+    /// Get the flag for a particular name.
+    fn from_name(name: &str) -> Option<Self>
+    where
+        Self: Sized;
+
     /// Iterate over enabled flag values.
     fn iter(&self) -> Self::Iter;
 
     /// Iterate over the raw names and bits for enabled flag values.
-    fn iter_raw(&self) -> Self::IterRaw;
+    fn iter_names(&self) -> Self::IterNames;
 
     /// Returns `true` if no flags are currently stored.
     fn is_empty(&self) -> bool;


### PR DESCRIPTION
This PR makes iterating and creating flags from their names consistent. It adds a `Flags::from_name` method that will match on the stringified flag identifier and return the flag for it. This can support cases where flags need to be parsed.