### PR TITLE
Forbid unsafe_code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,6 +340,7 @@
 
 #![cfg_attr(not(test), no_std)]
 #![doc(html_root_url = "https://docs.rs/bitflags/2.0.0-rc.1")]
+#![forbid(unsafe_code)]
 
 #[doc(inline)]
 pub use traits::BitFlags;


### PR DESCRIPTION
Fixes #222. Contrary to what is mentioned there, removing this annotation would not constitute a breaking change requiring a major version bump (at least according to normal Rust conventions). It is merely an assertion that the _current_ patch release contains no unsafe code.

Looking for `#![forbid(unsafe_code)]` is more reliable than trying to grep the crate source code for instances of "unsafe", since the latter could hypothetically be concealed by macros and such.