### PR TITLE
serde: enable no-std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ A macro to generate structures which behave like bitflags.
 exclude = ["tests", ".github"]
 
 [dependencies]
-serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
+serde = { version = "1.0", optional = true, default-features = false }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 compiler_builtins = { version = "0.1.2", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ A macro to generate structures which behave like bitflags.
 exclude = ["tests", ".github"]
 
 [dependencies]
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 compiler_builtins = { version = "0.1.2", optional = true }
 


### PR DESCRIPTION
Hi,

This PR enable no-std support on serde, ref. https://serde.rs/no-std.html

Otherwise, trying to compile a project with bitflags 2.0.0-rc.1 -F serde  on --target=thumbv7m-none-eabi currently hangs with a huge number of eg.
```
error[E0432]: unresolved imports `self::core::cmp`, `self::core::iter`, `self::core::mem`, `self::core::num`, `self::core::ptr`, `self::core::slice`, `self::core::str`
   --> /home/nim/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.152/src/lib.rs:167:26
```