### PR TITLE
Prepare for 2.0.0-rc.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 2.0.0-rc.2
+
+## Changes to `serde` serialization
+
+**⚠️ NOTE ⚠️** This release changes the default serialization you'll get if you `#[derive(Serialize, Deserialize)]`
+on your generated flags types. It will now use a formatted string for human-readable formats and the underlying bits
+type for compact formats.
+
+To keep the old behavior, see the [`bitflags-serde-legacy`](https://github.com/KodrAus/bitflags-serde-legacy) library.
+
+## What's Changed
+
+* Add missing "if" to contains doc-comment in traits.rs by @rusty-snake in https://github.com/bitflags/bitflags/pull/291
+* Forbid unsafe_code by @fintelia in https://github.com/bitflags/bitflags/pull/294
+* serde: enable no-std support by @nim65s in https://github.com/bitflags/bitflags/pull/296
+* Add a parser for flags formatted as bar-separated-values by @KodrAus in https://github.com/bitflags/bitflags/pull/297
+
+## New Contributors
+* @rusty-snake made their first contribution in https://github.com/bitflags/bitflags/pull/291
+* @fintelia made their first contribution in https://github.com/bitflags/bitflags/pull/294
+* @nim65s made their first contribution in https://github.com/bitflags/bitflags/pull/296
+
+**Full Changelog**: https://github.com/bitflags/bitflags/compare/2.0.0-rc.1...2.0.0-rc.2
+
 # 2.0.0-rc.1
 
 This is a big release including a few years worth of work on a new `BitFlags` trait, iteration, and better macro organization for future extensibility.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "bitflags"
 # NB: When modifying, also modify:
 #   1. html_root_url in lib.rs
 #   2. number in readme (for breaking changes)
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition = "2018"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bitflags = "2.0.0-rc.1"
+bitflags = "2.0.0-rc.2"
 ```
 
 and this to your source code:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,7 +344,7 @@
 //! ```
 
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
-#![doc(html_root_url = "https://docs.rs/bitflags/2.0.0-rc.1")]
+#![doc(html_root_url = "https://docs.rs/bitflags/2.0.0-rc.2")]
 #![forbid(unsafe_code)]
 
 #[doc(inline)]


### PR DESCRIPTION
**⚠️ NOTE ⚠️** This release changes the default serialization you'll get if you `#[derive(Serialize, Deserialize)]`
on your generated flags types. It will now use a formatted string for human-readable formats and the underlying bits
type for compact formats.

To keep the old behavior, see the [`bitflags-serde-legacy`](https://github.com/KodrAus/bitflags-serde-legacy) library.