### PR TITLE
Prepare for 2.0.0-rc.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.0-rc.3
+
+
+
 # 2.0.0-rc.2
 
 ## Changes to `serde` serialization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # 2.0.0-rc.3
 
+## What's Changed
+* Use strip_prefix instead of starts_with + slice by @QuinnPainter in https://github.com/bitflags/bitflags/pull/301
+* Fix up some clippy lints by @KodrAus in https://github.com/bitflags/bitflags/pull/302
 
+## New Contributors
+* @QuinnPainter made their first contribution in https://github.com/bitflags/bitflags/pull/301
+
+**Full Changelog**: https://github.com/bitflags/bitflags/compare/2.0.0-rc.2...2.0.0-rc.3
 
 # 2.0.0-rc.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "bitflags"
 # NB: When modifying, also modify:
 #   1. html_root_url in lib.rs
 #   2. number in readme (for breaking changes)
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition = "2018"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bitflags = "2.0.0-rc.2"
+bitflags = "2.0.0-rc.3"
 ```
 
 and this to your source code:


### PR DESCRIPTION
## What's Changed
* Use strip_prefix instead of starts_with + slice by @QuinnPainter in https://github.com/bitflags/bitflags/pull/301
* Fix up some clippy lints by @KodrAus in https://github.com/bitflags/bitflags/pull/302

## New Contributors
* @QuinnPainter made their first contribution in https://github.com/bitflags/bitflags/pull/301

**Full Changelog**: https://github.com/bitflags/bitflags/compare/2.0.0-rc.2...2.0.0-rc.3