### PR TITLE
Prepare for 2.0.0 release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: -Z avoid-dev-deps --features example_generated
+          working-directory: ./tests/smoke-test
 
   embedded:
     name: Build (embedded)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,12 +80,15 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install Rust toolchain
-        run: rustup default 1.56.0
+      - name: Install tombl
+        run: cargo install tombl
 
-      - name: Default features
-        run: cargo build
-        working-directory: ./tests/smoke-test
+      - name: Smoke test
+        run: |
+          eval $(tombl -e msrv=package.rust-version Cargo.toml)
+          rustup update $msrv
+          cd ./tests/smoke-test
+          cargo +$msrv build
 
   embedded:
     name: Build (embedded)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,6 +73,23 @@ jobs:
           command: bench
           args: --no-run
 
+  msrv:
+      name: MSRV
+      runs-on: ubuntu-latest
+      steps:
+          - name: Checkout sources
+            uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        run: |
+          rustup default 1.56.0
+
+      - name: Default features
+        uses: actions-rs/cargo@v1
+        with:
+            command: build
+            args: -Z avoid-dev-deps --features example_generated
+
   embedded:
     name: Build (embedded)
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,10 +84,8 @@ jobs:
         run: rustup default 1.56.0
 
       - name: Default features
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          working-directory: ./tests/smoke-test
+        run: cargo build
+        working-directory: ./tests/smoke-test
 
   embedded:
     name: Build (embedded)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,21 +74,20 @@ jobs:
           args: --no-run
 
   msrv:
-      name: MSRV
-      runs-on: ubuntu-latest
-      steps:
-          - name: Checkout sources
-            uses: actions/checkout@v2
+    name: MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
 
       - name: Install Rust toolchain
-        run: |
-          rustup default 1.56.0
+        run: rustup default 1.56.0
 
       - name: Default features
         uses: actions-rs/cargo@v1
         with:
-            command: build
-            args: -Z avoid-dev-deps --features example_generated
+          command: build
+          args: -Z avoid-dev-deps --features example_generated
 
   embedded:
     name: Build (embedded)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,47 @@
+# 2.0.0
+
+## What's Changed
+* Fix a typo and call out MSRV bump by @KodrAus in https://github.com/bitflags/bitflags/pull/259
+* BitFlags trait by @arturoc in https://github.com/bitflags/bitflags/pull/220
+* Add a hidden trait to discourage manual impls of BitFlags by @KodrAus in https://github.com/bitflags/bitflags/pull/261
+* Sanitize `Ok` by @konsumlamm in https://github.com/bitflags/bitflags/pull/266
+* Fix bug in `Debug` implementation by @konsumlamm in https://github.com/bitflags/bitflags/pull/268
+* Fix a typo in the generated documentation by @wackbyte in https://github.com/bitflags/bitflags/pull/271
+* Use SPDX license format by @atouchet in https://github.com/bitflags/bitflags/pull/272
+* serde tests fail in CI by @arturoc in https://github.com/bitflags/bitflags/pull/277
+* Fix beta test output by @KodrAus in https://github.com/bitflags/bitflags/pull/279
+* Add example to the README.md file by @tiaanl in https://github.com/bitflags/bitflags/pull/270
+* Iterator over all the enabled options by @arturoc in https://github.com/bitflags/bitflags/pull/278
+* from_bits_(truncate) fail with composite flags by @arturoc in https://github.com/bitflags/bitflags/pull/276
+* Add more platform coverage to CI by @KodrAus in https://github.com/bitflags/bitflags/pull/280
+* rework the way cfgs are handled by @KodrAus in https://github.com/bitflags/bitflags/pull/281
+* Split generated code into two types by @KodrAus in https://github.com/bitflags/bitflags/pull/282
+* expose bitflags iters using nameable types by @KodrAus in https://github.com/bitflags/bitflags/pull/286
+* Support creating flags from their names by @KodrAus in https://github.com/bitflags/bitflags/pull/287
+* Update README.md by @KodrAus in https://github.com/bitflags/bitflags/pull/288
+* Prepare for 2.0.0-rc.1 release by @KodrAus in https://github.com/bitflags/bitflags/pull/289
+* Add missing "if" to contains doc-comment in traits.rs by @rusty-snake in https://github.com/bitflags/bitflags/pull/291
+* Forbid unsafe_code by @fintelia in https://github.com/bitflags/bitflags/pull/294
+* serde: enable no-std support by @nim65s in https://github.com/bitflags/bitflags/pull/296
+* Add a parser for flags formatted as bar-separated-values by @KodrAus in https://github.com/bitflags/bitflags/pull/297
+* Prepare for 2.0.0-rc.2 release by @KodrAus in https://github.com/bitflags/bitflags/pull/299
+* Use strip_prefix instead of starts_with + slice by @QuinnPainter in https://github.com/bitflags/bitflags/pull/301
+* Fix up some clippy lints by @KodrAus in https://github.com/bitflags/bitflags/pull/302
+* Prepare for 2.0.0-rc.3 release by @KodrAus in https://github.com/bitflags/bitflags/pull/303
+* feat: Add minimum permissions to rust.yml workflow by @gabibguti in https://github.com/bitflags/bitflags/pull/305
+
+## New Contributors
+* @wackbyte made their first contribution in https://github.com/bitflags/bitflags/pull/271
+* @atouchet made their first contribution in https://github.com/bitflags/bitflags/pull/272
+* @tiaanl made their first contribution in https://github.com/bitflags/bitflags/pull/270
+* @rusty-snake made their first contribution in https://github.com/bitflags/bitflags/pull/291
+* @fintelia made their first contribution in https://github.com/bitflags/bitflags/pull/294
+* @nim65s made their first contribution in https://github.com/bitflags/bitflags/pull/296
+* @QuinnPainter made their first contribution in https://github.com/bitflags/bitflags/pull/301
+* @gabibguti made their first contribution in https://github.com/bitflags/bitflags/pull/305
+
+**Full Changelog**: https://github.com/bitflags/bitflags/compare/1.3.2...2.0.0
+
 # 2.0.0-rc.3
 
 ## What's Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ name = "bitflags"
 #   2. number in readme (for breaking changes)
 version = "2.0.0"
 edition = "2021"
+rust-version = "1.56.0"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 keywords = ["bit", "bitmask", "bitflags", "flags"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ name = "bitflags"
 # NB: When modifying, also modify:
 #   1. html_root_url in lib.rs
 #   2. number in readme (for breaking changes)
-version = "2.0.0-rc.3"
-edition = "2018"
+version = "2.0.0"
+edition = "2021"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 keywords = ["bit", "bitmask", "bitflags", "flags"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bitflags = "2.0.0-rc.3"
+bitflags = "2.0.0"
 ```
 
 and this to your source code:

--- a/README.md
+++ b/README.md
@@ -56,4 +56,5 @@ fn main() {
 
 ## Rust Version Support
 
-The minimum supported Rust version is 1.56.0. This may be bumped in minor releases as necessary.
+The minimum supported Rust version is documented in the `Cargo.toml` file.
+This may be bumped in minor releases as necessary.

--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ fn main() {
 
 ## Rust Version Support
 
-The minimum supported Rust version is 1.46 due to use of associated constants and const functions.
+The minimum supported Rust version is 1.56.0. This may be bumped in minor releases as necessary.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1498,6 +1498,17 @@ mod tests {
         assert_eq!(iter.next().unwrap(), ("ONE", Flags::ONE));
         assert_eq!(iter.next().unwrap(), ("THREE", Flags::THREE));
         assert_eq!(iter.next(), None);
+
+        let flags = Flags::from_bits_retain(0b1000_0000);
+        assert_eq!(flags.into_iter().count(), 1);
+        assert_eq!(flags.iter_names().count(), 0);
+    }
+
+    #[test]
+    fn into_iter_from_iter_roundtrip() {
+        let flags = Flags::ABC | Flags::from_bits_retain(0b1000_0000);
+
+        assert_eq!(flags, flags.into_iter().collect::<Flags>());
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,17 +1,29 @@
 //! Parsing flags from text.
 //!
-//! `bitflags` defines the following whitespace-insensitive grammar for flags formatted
+//! `bitflags` defines the following *whitespace-insensitive*, *case-sensitive* grammar for flags formatted
 //! as text:
 //!
 //! - _Flags:_ (_Flag_)`|`*
 //! - _Flag:_ _Identifier_ | _HexNumber_
 //! - _Identifier:_ Any Rust identifier
-//! - _HexNumber_: `0x`([0-9a-zA-Z])*
+//! - _HexNumber_: `0x`([0-9a-fA-F])*
 //!
 //! As an example, this is how `Flags::A | Flags::B | 0x0c` can be represented as text:
 //!
 //! ```text
 //! A | B | 0x0c
+//! ```
+//!
+//! Alternatively, it could be represented without whitespace:
+//!
+//! ```text
+//! A|B|0x0C
+//! ```
+//!
+//! Note that identifiers are *case-sensitive*, so the following is *not equivalent*:
+//!
+//! ```text
+//! a | b | 0x0c
 //! ```
 
 #![allow(clippy::let_unit_value)]


### PR DESCRIPTION
## What's Changed
* Fix a typo and call out MSRV bump by @KodrAus in https://github.com/bitflags/bitflags/pull/259
* BitFlags trait by @arturoc in https://github.com/bitflags/bitflags/pull/220
* Add a hidden trait to discourage manual impls of BitFlags by @KodrAus in https://github.com/bitflags/bitflags/pull/261
* Sanitize `Ok` by @konsumlamm in https://github.com/bitflags/bitflags/pull/266
* Fix bug in `Debug` implementation by @konsumlamm in https://github.com/bitflags/bitflags/pull/268
* Fix a typo in the generated documentation by @wackbyte in https://github.com/bitflags/bitflags/pull/271
* Use SPDX license format by @atouchet in https://github.com/bitflags/bitflags/pull/272
* serde tests fail in CI by @arturoc in https://github.com/bitflags/bitflags/pull/277
* Fix beta test output by @KodrAus in https://github.com/bitflags/bitflags/pull/279
* Add example to the README.md file by @tiaanl in https://github.com/bitflags/bitflags/pull/270
* Iterator over all the enabled options by @arturoc in https://github.com/bitflags/bitflags/pull/278
* from_bits_(truncate) fail with composite flags by @arturoc in https://github.com/bitflags/bitflags/pull/276
* Add more platform coverage to CI by @KodrAus in https://github.com/bitflags/bitflags/pull/280
* rework the way cfgs are handled by @KodrAus in https://github.com/bitflags/bitflags/pull/281
* Split generated code into two types by @KodrAus in https://github.com/bitflags/bitflags/pull/282
* expose bitflags iters using nameable types by @KodrAus in https://github.com/bitflags/bitflags/pull/286
* Support creating flags from their names by @KodrAus in https://github.com/bitflags/bitflags/pull/287
* Update README.md by @KodrAus in https://github.com/bitflags/bitflags/pull/288
* Prepare for 2.0.0-rc.1 release by @KodrAus in https://github.com/bitflags/bitflags/pull/289
* Add missing "if" to contains doc-comment in traits.rs by @rusty-snake in https://github.com/bitflags/bitflags/pull/291
* Forbid unsafe_code by @fintelia in https://github.com/bitflags/bitflags/pull/294
* serde: enable no-std support by @nim65s in https://github.com/bitflags/bitflags/pull/296
* Add a parser for flags formatted as bar-separated-values by @KodrAus in https://github.com/bitflags/bitflags/pull/297
* Prepare for 2.0.0-rc.2 release by @KodrAus in https://github.com/bitflags/bitflags/pull/299
* Use strip_prefix instead of starts_with + slice by @QuinnPainter in https://github.com/bitflags/bitflags/pull/301
* Fix up some clippy lints by @KodrAus in https://github.com/bitflags/bitflags/pull/302
* Prepare for 2.0.0-rc.3 release by @KodrAus in https://github.com/bitflags/bitflags/pull/303
* feat: Add minimum permissions to rust.yml workflow by @gabibguti in https://github.com/bitflags/bitflags/pull/305

## New Contributors
* @wackbyte made their first contribution in https://github.com/bitflags/bitflags/pull/271
* @atouchet made their first contribution in https://github.com/bitflags/bitflags/pull/272
* @tiaanl made their first contribution in https://github.com/bitflags/bitflags/pull/270
* @rusty-snake made their first contribution in https://github.com/bitflags/bitflags/pull/291
* @fintelia made their first contribution in https://github.com/bitflags/bitflags/pull/294
* @nim65s made their first contribution in https://github.com/bitflags/bitflags/pull/296
* @QuinnPainter made their first contribution in https://github.com/bitflags/bitflags/pull/301
* @gabibguti made their first contribution in https://github.com/bitflags/bitflags/pull/305