### PR TITLE
Fix formatting of multi-bit flags with partial overlap

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -89,7 +89,8 @@ macro_rules! __impl_internal_bitflags {
 
                 // Iterate over the valid flags
                 let mut first = true;
-                for (name, _) in self.iter_names() {
+                let mut iter = self.iter_names();
+                for (name, _) in &mut iter {
                     if !first {
                         f.write_str(" | ")?;
                     }
@@ -99,8 +100,7 @@ macro_rules! __impl_internal_bitflags {
                 }
 
                 // Append any extra bits that correspond to flags to the end of the format
-                let extra_bits = self.bits & !Self::all().bits;
-
+                let extra_bits = iter.state.bits();
                 if extra_bits != <$T as $crate::__private::Bits>::EMPTY {
                     if !first {
                         f.write_str(" | ")?;


### PR DESCRIPTION
Fixes #315

cc @mxk

I've added a repro for the bug reported here: https://github.com/bitflags/bitflags/issues/310#issuecomment-1470122112

It looks like we'll need to tweak the `iter_names` method to make sure we include any remaining bits when they overlap, but don't complete, a multi-bit flag.