### PR TITLE
Prepare for 2.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 2.0.1
+
+## What's Changed
+* Fix up some docs issues by @KodrAus in https://github.com/bitflags/bitflags/pull/309
+* Make empty_flag() const. by @tormeh in https://github.com/bitflags/bitflags/pull/313
+* Fix formatting of multi-bit flags with partial overlap by @KodrAus in https://github.com/bitflags/bitflags/pull/316
+
+## New Contributors
+* @tormeh made their first contribution in https://github.com/bitflags/bitflags/pull/313
+
+**Full Changelog**: https://github.com/bitflags/bitflags/compare/2.0.0...2.0.1
+
 # 2.0.0
 
 ## What's Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "bitflags"
 # NB: When modifying, also modify:
 #   1. html_root_url in lib.rs
 #   2. number in readme (for breaking changes)
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.56.0"
 authors = ["The Rust Project Developers"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bitflags = "2.0.0"
+bitflags = "2.0.1"
 ```
 
 and this to your source code:


### PR DESCRIPTION
## What's Changed
* Fix up some docs issues by @KodrAus in https://github.com/bitflags/bitflags/pull/309
* Make empty_flag() const. by @tormeh in https://github.com/bitflags/bitflags/pull/313
* Fix formatting of multi-bit flags with partial overlap by @KodrAus in https://github.com/bitflags/bitflags/pull/316

## New Contributors
* @tormeh made their first contribution in https://github.com/bitflags/bitflags/pull/313

**Full Changelog**: https://github.com/bitflags/bitflags/compare/2.0.0...2.0.1