### PR TITLE
Prepare for 2.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.0.2
+
+## What's Changed
+* Fix up missing isize and usize Bits impls by @KodrAus in https://github.com/bitflags/bitflags/pull/321
+
+**Full Changelog**: https://github.com/bitflags/bitflags/compare/2.0.1...2.0.2
+
 # 2.0.1
 
 ## What's Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "bitflags"
 # NB: When modifying, also modify:
 #   1. html_root_url in lib.rs
 #   2. number in readme (for breaking changes)
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 rust-version = "1.56.0"
 authors = ["The Rust Project Developers"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bitflags = "2.0.1"
+bitflags = "2.0.2"
 ```
 
 and this to your source code:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,7 +344,7 @@
 //! ```
 
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
-#![doc(html_root_url = "https://docs.rs/bitflags/2.0.0")]
+#![doc(html_root_url = "https://docs.rs/bitflags/2.0.2")]
 #![forbid(unsafe_code)]
 
 #[doc(inline)]


### PR DESCRIPTION
## What's Changed
* Fix up missing isize and usize Bits impls by @KodrAus in https://github.com/bitflags/bitflags/pull/321

**Full Changelog**: https://github.com/bitflags/bitflags/compare/2.0.1...2.0.2