### PR TITLE
Add support for arbitrary

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,7 @@ jobs:
       run: cargo install cargo-hack
 
     - name: Powerset
-      run: cargo hack test --feature-powerset --lib --optional-deps "std serde" --depth 3 --skip rustc-dep-of-std
+      run: cargo hack test --feature-powerset --lib --optional-deps --depth 3 --skip "compiler_builtins core rustc-dep-of-std"
 
     - name: Docs
       run: cargo doc --features example_generated

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ exclude = ["tests", ".github"]
 
 [dependencies]
 serde = { version = "1.0", optional = true, default-features = false }
+arbitrary = { version = "1.0", optional = true }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 compiler_builtins = { version = "0.1.2", optional = true }
 
@@ -30,6 +31,7 @@ rustversion = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 serde_test = "1.0"
+arbitrary = { version = "1.0", features = ["derive"] }
 
 [features]
 std = []

--- a/src/external/arbitrary_support.rs
+++ b/src/external/arbitrary_support.rs
@@ -1,0 +1,19 @@
+#[cfg(test)]
+mod tests {
+    use arbitrary::Arbitrary;
+
+    bitflags! {
+        #[derive(Arbitrary)]
+        struct Color: u32 {
+            const RED = 0x1;
+            const GREEN = 0x2;
+            const BLUE = 0x4;
+        }
+    }
+
+    #[test]
+    fn test_arbitrary() {
+        let mut unstructured = arbitrary::Unstructured::new(&[0_u8; 256]);
+        let _color = Color::arbitrary(&mut unstructured);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,6 +361,9 @@ pub mod __private {
 
     #[cfg(feature = "serde")]
     pub use serde;
+
+    #[cfg(feature = "arbitrary")]
+    pub use arbitrary;
 }
 
 /*


### PR DESCRIPTION
Closes #248
Follow-up from #260

Well, after our 2 year yak-shave we can now actually add `arbitrary` support to generated flags types without potentially breaking users who want to implement it manually :tada:

r? @sunfishcode