### PR TITLE
Fix up missing docs for consts within consts

### DIFF
--- a/src/example_generated.rs
+++ b/src/example_generated.rs
@@ -28,7 +28,11 @@ __impl_internal_bitflags! {
 }
 
 __impl_public_bitflags! {
-    Flags: u32, Field0, Iter, IterRaw {
+    Flags: u32, Field0, Iter, IterRaw;
+}
+
+__impl_public_bitflags_consts! {
+    Flags {
         A = 0b00000001;
         B = 0b00000010;
         C = 0b00000100;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -544,6 +544,22 @@ macro_rules! bitflags {
             $vis struct $BitFlags;
         }
 
+        // Workaround for: https://github.com/bitflags/bitflags/issues/320
+        __impl_public_bitflags_consts! {
+            $BitFlags {
+                $(
+                    $(#[$inner $($args)*])*
+                    #[allow(
+                        dead_code,
+                        deprecated,
+                        unused_attributes,
+                        non_upper_case_globals
+                    )]
+                    $Flag = $value;
+                )*
+            }
+        }
+
         #[allow(
             dead_code,
             deprecated,
@@ -582,12 +598,7 @@ macro_rules! bitflags {
             }
 
             __impl_public_bitflags! {
-                $BitFlags: $T, InternalBitFlags, Iter, IterRaw {
-                    $(
-                        $(#[$inner $($args)*])*
-                        $Flag = $value;
-                    )*
-                }
+                $BitFlags: $T, InternalBitFlags, Iter, IterRaw;
             }
         };
 

--- a/src/public.rs
+++ b/src/public.rs
@@ -26,12 +26,7 @@ macro_rules! __declare_public_bitflags {
 #[doc(hidden)]
 macro_rules! __impl_public_bitflags {
     (
-        $PublicBitFlags:ident: $T:ty, $InternalBitFlags:ident, $Iter:ident, $IterNames:ident {
-            $(
-                $(#[$attr:ident $($args:tt)*])*
-                $Flag:ident = $value:expr;
-            )*
-        }
+        $PublicBitFlags:ident: $T:ty, $InternalBitFlags:ident, $Iter:ident, $IterNames:ident;
     ) => {
         impl $crate::__private::core::fmt::Binary for $PublicBitFlags {
             fn fmt(&self, f: &mut $crate::__private::core::fmt::Formatter) -> $crate::__private::core::fmt::Result {
@@ -58,11 +53,6 @@ macro_rules! __impl_public_bitflags {
         }
 
         impl $PublicBitFlags {
-            $(
-                $(#[$attr $($args)*])*
-                pub const $Flag: Self = Self::from_bits_retain($value);
-            )*
-
             /// Returns an empty set of flags.
             #[inline]
             pub const fn empty() -> Self {
@@ -452,5 +442,26 @@ macro_rules! __impl_public_bitflags {
         }
 
         impl $crate::__private::ImplementedByBitFlagsMacro for $PublicBitFlags {}
+    };
+}
+
+/// Implement constants on the public (user-facing) bitflags type.
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! __impl_public_bitflags_consts {
+    (
+        $PublicBitFlags:ident {
+            $(
+                $(#[$attr:ident $($args:tt)*])*
+                $Flag:ident = $value:expr;
+            )*
+        }
+    ) => {
+        impl $PublicBitFlags {
+            $(
+                $(#[$attr $($args)*])*
+                pub const $Flag: Self = Self::from_bits_retain($value);
+            )*
+        }
     };
 }


### PR DESCRIPTION
Closes #320 

Moves the declaration of associated constants for flags outside of the `const _: () { .. }` container. This works around a bug in the current stable version of `rustdoc` where docs for constants within `#[doc(hidden)]` constants are missed.