### PR TITLE
Ignore clippy lint in generated code

### DIFF
--- a/src/external/serde_support.rs
+++ b/src/external/serde_support.rs
@@ -39,7 +39,7 @@ where
         {
             type Value = T;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a string value of `|` separated flags")
             }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -407,6 +407,7 @@ macro_rules! __impl_internal_bitflags {
                 if self.state.is_empty() || NUM_FLAGS == 0 {
                     $crate::__private::core::option::Option::None
                 } else {
+                    #[allow(clippy::indexing_slicing)]
                     for (flag, flag_name) in OPTIONS[self.idx..NUM_FLAGS].iter().copied()
                         .zip(OPTIONS_NAMES[self.idx..NUM_FLAGS].iter().copied())
                     {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -60,7 +60,7 @@ macro_rules! __impl_internal_bitflags {
         }
 
         impl $crate::__private::core::fmt::Debug for $InternalBitFlags {
-            fn fmt(&self, f: &mut $crate::__private::core::fmt::Formatter) -> $crate::__private::core::fmt::Result {
+            fn fmt(&self, f: &mut $crate::__private::core::fmt::Formatter<'_>) -> $crate::__private::core::fmt::Result {
                 if self.is_empty() {
                     // If no flags are set then write an empty hex flag to avoid
                     // writing an empty string. In some contexts, like serialization,
@@ -78,7 +78,7 @@ macro_rules! __impl_internal_bitflags {
         }
 
         impl $crate::__private::core::fmt::Display for $InternalBitFlags {
-            fn fmt(&self, f: &mut $crate::__private::core::fmt::Formatter) -> $crate::__private::core::fmt::Result {
+            fn fmt(&self, f: &mut $crate::__private::core::fmt::Formatter<'_>) -> $crate::__private::core::fmt::Result {
                 // A formatter for bitflags that produces text output like:
                 //
                 // A | B | 0xf6

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -88,7 +88,7 @@ impl ParseError {
 }
 
 impl fmt::Display for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
             ParseErrorKind::InvalidNamedFlag { got } => {
                 let _got = got;


### PR DESCRIPTION
If a project enables https://rust-lang.github.io/rust-clippy/master/index.html the code generated by the macro will emit the warning, which for many projects will also fail CI.