### PR TITLE
Add support for bytemuck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ exclude = ["tests", ".github"]
 [dependencies]
 serde = { version = "1.0", optional = true, default-features = false }
 arbitrary = { version = "1.0", optional = true }
+bytemuck = { version = "1.0", optional = true }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 compiler_builtins = { version = "0.1.2", optional = true }
 
@@ -32,6 +33,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 serde_test = "1.0"
 arbitrary = { version = "1.0", features = ["derive"] }
+bytemuck = { version = "1.0", features = ["derive"] }
 
 [features]
 std = []

--- a/src/external.rs
+++ b/src/external.rs
@@ -118,7 +118,7 @@ macro_rules! __impl_external_bitflags {
                 $(
                     $(#[$attr $($args)*])*
                     $Flag;
-                    )*
+                )*
             }
         }
     };

--- a/src/external.rs
+++ b/src/external.rs
@@ -225,6 +225,8 @@ macro_rules! __impl_external_bitflags_bytemuck {
                 )*
         }
     ) => {
+        // SAFETY: $InternalBitFlags is guaranteed to have the same ABI as $T,
+        // and $T implements Pod
         unsafe impl $crate::__private::bytemuck::Pod for $InternalBitFlags
         where
             $T: $crate::__private::bytemuck::Pod,
@@ -232,6 +234,8 @@ macro_rules! __impl_external_bitflags_bytemuck {
 
         }
 
+        // SAFETY: $InternalBitFlags is guaranteed to have the same ABI as $T,
+        // and $T implements Zeroable
         unsafe impl $crate::__private::bytemuck::Zeroable for $InternalBitFlags
         where
             $T: $crate::__private::bytemuck::Zeroable,

--- a/src/external/bytemuck_support.rs
+++ b/src/external/bytemuck_support.rs
@@ -1,0 +1,19 @@
+#[cfg(test)]
+mod tests {
+    use bytemuck::{Pod, Zeroable};
+    
+    bitflags! {
+        #[derive(Pod, Zeroable, Clone, Copy)]
+        #[repr(transparent)]
+        struct Color: u32 {
+            const RED = 0x1;
+            const GREEN = 0x2;
+            const BLUE = 0x4;
+        }
+    }
+
+    #[test]
+    fn test_bytemuck() {
+        assert_eq!(0x1, bytemuck::cast::<Color, u32>(Color::RED));
+    }
+}

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -14,6 +14,9 @@ macro_rules! __declare_internal_bitflags {
         $iter_vis:vis struct $Iter:ident;
         $iter_names_vis:vis struct $IterNames:ident;
     ) => {
+        // NOTE: The ABI of this type is _guaranteed_ to be the same as `T`
+        // This is relied on by some external libraries like `bytemuck` to make
+        // its `unsafe` trait impls sound.
         #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
         #[repr(transparent)]
         $vis struct $InternalBitFlags {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,8 +394,9 @@
 //! example docs.
 
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
+#![cfg_attr(not(test), forbid(unsafe_code))]
+
 #![doc(html_root_url = "https://docs.rs/bitflags/2.1.0")]
-#![forbid(unsafe_code)]
 
 #[doc(inline)]
 pub use traits::BitFlags;
@@ -408,12 +409,6 @@ pub mod __private {
     pub use crate::{external::*, traits::*};
 
     pub use core;
-
-    #[cfg(feature = "serde")]
-    pub use serde;
-
-    #[cfg(feature = "arbitrary")]
-    pub use arbitrary;
 }
 
 /*

--- a/src/public.rs
+++ b/src/public.rs
@@ -14,7 +14,7 @@ macro_rules! __declare_public_bitflags {
         $vis:vis struct $BitFlags:ident;
     ) => {
         $(#[$outer])*
-        $vis struct $BitFlags(<Self as $crate::__private::PublicFlags>::Internal);
+        $vis struct $BitFlags(<$BitFlags as $crate::__private::PublicFlags>::Internal);
     };
 }
 


### PR DESCRIPTION
Closes #311 

I've also added some docs on how to support external libraries here for future contributors. Since the `bytemuck` impls themselves are `unsafe`, I've added a note to where we generate our internal flags type warning that its ABI can't be changed.