### PR TITLE
add docs to describe the behavior of multi-bit flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,6 +350,33 @@
 //!
 //! Users should generally avoid defining a flag with a value of zero.
 //!
+//! ## Multi-bit Flags
+//!
+//! It is allowed to define a flag with multiple bits set, however such
+//! flags are _not_ treated as a set where any of those bits is a valid
+//! flag. Instead, each flag is treated as a unit when converting from
+//! bits with [`from_bits`] or [`from_bits_truncate`].
+//!
+//! ```
+//! use bitflags::bitflags;
+//!
+//! bitflags! {
+//!     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+//!     struct Flags: u8 {
+//!         const F3 = 0b00000011;
+//!     }
+//! }
+//!
+//! fn main() {
+//!     // This bit pattern does not set all the bits in `F3`, so it is rejected.
+//!     assert!(Flags::from_bits(0b00000001).is_none());
+//!     assert!(Flags::from_bits_truncate(0b00000001).is_empty());
+//! }
+//! ```
+//!
+//! [`from_bits`]: BitFlags::from_bits
+//! [`from_bits_truncate`]: BitFlags::from_bits_truncate
+//!
 //! # The `BitFlags` trait
 //!
 //! This library defines a `BitFlags` trait that's implemented by all generated flags types.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -24,12 +24,20 @@ pub trait BitFlags: ImplementedByBitFlagsMacro {
 
     /// Convert from underlying bit representation, unless that
     /// representation contains bits that do not correspond to a flag.
+    ///
+    /// Note that each [multi-bit flag] is treated as a unit for this comparison.
+    ///
+    /// [multi-bit flag]: index.html#multi-bit-flags
     fn from_bits(bits: Self::Bits) -> Option<Self>
     where
         Self: Sized;
 
     /// Convert from underlying bit representation, dropping any bits
     /// that do not correspond to flags.
+    ///
+    /// Note that each [multi-bit flag] is treated as a unit for this comparison.
+    ///
+    /// [multi-bit flag]: index.html#multi-bit-flags
     fn from_bits_truncate(bits: Self::Bits) -> Self;
 
     /// Convert from underlying bit representation, preserving all


### PR DESCRIPTION
This clears up possible confusion about how a flag that defines multiple bits behaves when calling `from_bits` or `from_bits_truncate`. Those functions do not treat multi-bit flags as a set of possible bits that can be set, but rather as a unit where the bits must exactly match one of the defined flags.