### PR TITLE
Prepare for 2.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.3.0
+
+## What's Changed
+* Support ejecting flags types from the bitflags macro by @KodrAus in https://github.com/bitflags/bitflags/pull/351
+
+**Full Changelog**: https://github.com/bitflags/bitflags/compare/2.2.1...2.3.0
+
 # 2.2.1
 
 ## What's Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "bitflags"
 # NB: When modifying, also modify:
 #   1. html_root_url in lib.rs
 #   2. number in readme (for breaking changes)
-version = "2.2.1"
+version = "2.3.0"
 edition = "2021"
 rust-version = "1.56.0"
 authors = ["The Rust Project Developers"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bitflags = "2.2.1"
+bitflags = "2.3.0"
 ```
 
 and this to your source code:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,7 +422,7 @@
 
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![cfg_attr(not(test), forbid(unsafe_code))]
-#![doc(html_root_url = "https://docs.rs/bitflags/2.2.1")]
+#![doc(html_root_url = "https://docs.rs/bitflags/2.3.0")]
 
 #[doc(inline)]
 pub use traits::{Flags, Flag, Bits};


### PR DESCRIPTION
## What's Changed
* Use explicit hashes for actions steps by @KodrAus in https://github.com/bitflags/bitflags/pull/350
* Support ejecting flags types from the bitflags macro by @KodrAus in https://github.com/bitflags/bitflags/pull/351