### PR TITLE
fix clippy assign_op_pattern warnings

### DIFF
--- a/src/public.rs
+++ b/src/public.rs
@@ -173,7 +173,7 @@ macro_rules! __impl_public_bitflags {
                             $(#[$attr $($args)*])*
                             {
                                 if bits & $PublicBitFlags::$Flag.bits() == $PublicBitFlags::$Flag.bits() {
-                                    truncated = truncated | $PublicBitFlags::$Flag.bits()
+                                    truncated |= $PublicBitFlags::$Flag.bits()
                                 }
                             }
                         );
@@ -219,15 +219,15 @@ macro_rules! __impl_public_bitflags {
                 }
 
                 fn insert(f, other) {
-                    f.0 = f.0 | other.0;
+                    f.0 |= other.0;
                 }
 
                 fn remove(f, other) {
-                    f.0 = f.0 & !other.0;
+                    f.0 &= !other.0;
                 }
 
                 fn toggle(f, other) {
-                    f.0 = f.0 ^ other.0;
+                    f.0 ^= other.0;
                 }
 
                 fn set(f, other, value) {
@@ -337,7 +337,7 @@ macro_rules! __impl_public_bitflags_ops {
             /// Adds the set of flags.
             #[inline]
             fn bitor_assign(&mut self, other: Self) {
-                self.0 = self.0 | other.0;
+                self.0 |= other.0;
             }
         }
 
@@ -355,7 +355,7 @@ macro_rules! __impl_public_bitflags_ops {
             /// Toggles the set of flags.
             #[inline]
             fn bitxor_assign(&mut self, other: Self) {
-                self.0 = self.0 ^ other.0
+                self.0 ^= other.0
             }
         }
 
@@ -391,7 +391,7 @@ macro_rules! __impl_public_bitflags_ops {
             /// Disables all flags enabled in the set.
             #[inline]
             fn sub_assign(&mut self, other: Self) {
-                self.0 = self.0 & !other.0;
+                self.0 &= !other.0;
             }
         }
 


### PR DESCRIPTION
I'm currently seeing clippy warnings like:
```
warning: manual implementation of an assign operation
   --> uapi/src/v1.rs:457:1
    |
457 | / bitflags! {
458 | |     /// Additional configuration flags for event requests.
459 | |     #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
460 | |     pub struct EventRequestFlags: u32 {
...   |
469 | |     }
470 | | }
    | |_^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern
    = note: this warning originates in the macro `__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This patch addresses those by replacing occurrences of `a = a op b` to `a op= b`, as suggested by the info link.
Not sure of that is all of them - but it is at least all that my code was triggering.