### PR TITLE
Fix Self in flags value expressions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,7 +89,9 @@ jobs:
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
 
       - name: Install Clippy
-        run: rustup component add clippy --toolchain beta
+        run: |
+          rustup update beta
+          rustup component add clippy --toolchain beta
 
       - name: Default features
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,6 +81,21 @@ jobs:
       - name: Default features
         run: cross test --target mips-unknown-linux-gnu
 
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      - name: Install Clippy
+        run: rustup component add clippy --toolchain beta
+
+      - name: Default features
+        run: |
+          cd ./tests/smoke-test
+          cargo +beta clippy
+
   embedded:
     name: Build (embedded)
     runs-on: ubuntu-latest

--- a/src/example_generated.rs
+++ b/src/example_generated.rs
@@ -39,7 +39,7 @@ __impl_public_bitflags_forward! {
 }
 
 __impl_public_bitflags_iter! {
-    Flags
+    Flags: u32, Flags
 }
 
 __impl_public_bitflags_consts! {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -98,7 +98,7 @@ macro_rules! __impl_internal_bitflags {
         // The internal flags type offers a similar API to the public one
 
         __impl_public_bitflags! {
-            $InternalBitFlags: $T {
+            $InternalBitFlags: $T, $PublicBitFlags {
                 $(
                     $(#[$attr $($args)*])*
                     $Flag;
@@ -106,19 +106,8 @@ macro_rules! __impl_internal_bitflags {
             }
         }
 
-        __impl_public_bitflags_consts! {
-            $InternalBitFlags: $T {
-                $(
-                    $(#[$attr $($args)*])*
-                    #[allow(
-                        dead_code,
-                        deprecated,
-                        unused_attributes,
-                        non_upper_case_globals
-                    )]
-                    $Flag = $value;
-                )*
-            }
+        __impl_public_bitflags_iter! {
+            $InternalBitFlags: $T, $PublicBitFlags
         }
 
         impl $InternalBitFlags {
@@ -126,18 +115,6 @@ macro_rules! __impl_internal_bitflags {
             #[inline]
             pub fn bits_mut(&mut self) -> &mut $T {
                 &mut self.0
-            }
-
-            /// Iterate over enabled flag values.
-            #[inline]
-            pub const fn iter(&self) -> $crate::iter::Iter<$PublicBitFlags> {
-                $crate::iter::Iter::__private_const_new(<$PublicBitFlags as $crate::Flags>::FLAGS, $PublicBitFlags::from_bits_retain(self.0), $PublicBitFlags::from_bits_retain(self.0))
-            }
-
-            /// Iterate over enabled flag values with their stringified names.
-            #[inline]
-            pub const fn iter_names(&self) -> $crate::iter::IterNames<$PublicBitFlags> {
-                $crate::iter::IterNames::__private_const_new(<$PublicBitFlags as $crate::Flags>::FLAGS, $PublicBitFlags::from_bits_retain(self.0), $PublicBitFlags::from_bits_retain(self.0))
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -590,7 +590,8 @@ macro_rules! bitflags {
             unused_attributes,
             unused_mut,
             unused_imports,
-            non_upper_case_globals
+            non_upper_case_globals,
+            clippy::assign_op_pattern
         )]
         const _: () = {
             // Declared in a "hidden" scope that can't be reached directly
@@ -610,7 +611,7 @@ macro_rules! bitflags {
 
             // This is where new library trait implementations can be added
             __impl_external_bitflags! {
-                InternalBitFlags: $T {
+                InternalBitFlags: $T, $BitFlags {
                     $(
                         $(#[$inner $($args)*])*
                         $Flag;
@@ -623,7 +624,7 @@ macro_rules! bitflags {
             }
 
             __impl_public_bitflags_iter! {
-                $BitFlags
+                $BitFlags: $T, $BitFlags
             }
         };
 
@@ -657,11 +658,12 @@ macro_rules! bitflags {
             unused_attributes,
             unused_mut,
             unused_imports,
-            non_upper_case_globals
+            non_upper_case_globals,
+            clippy::assign_op_pattern
         )]
         const _: () = {
             __impl_public_bitflags! {
-                $BitFlags: $T {
+                $BitFlags: $T, $BitFlags {
                     $(
                         $(#[$inner $($args)*])*
                         $Flag;
@@ -670,7 +672,7 @@ macro_rules! bitflags {
             }
 
             __impl_public_bitflags_iter! {
-                $BitFlags
+                $BitFlags: $T, $BitFlags
             }
         };
 

--- a/src/public.rs
+++ b/src/public.rs
@@ -57,7 +57,7 @@ macro_rules! __impl_public_bitflags_forward {
                     Self($InternalBitFlags::from_bits_retain(bits))
                 }
 
-                fn from_name(name){
+                fn from_name(name) {
                     match $InternalBitFlags::from_name(name) {
                         $crate::__private::core::option::Option::Some(bits) => $crate::__private::core::option::Option::Some(Self(bits)),
                         $crate::__private::core::option::Option::None => $crate::__private::core::option::Option::None,
@@ -130,7 +130,7 @@ macro_rules! __impl_public_bitflags_forward {
 #[doc(hidden)]
 macro_rules! __impl_public_bitflags {
     (
-        $PublicBitFlags:ident: $T:ty {
+        $BitFlags:ident: $T:ty, $PublicBitFlags:ident {
             $(
                 $(#[$attr:ident $($args:tt)*])*
                 $Flag:ident;
@@ -138,7 +138,7 @@ macro_rules! __impl_public_bitflags {
         }
     ) => {
         __impl_bitflags! {
-            $PublicBitFlags: $T {
+            $BitFlags: $T {
                 fn empty() {
                     Self(<$T as $crate::Bits>::EMPTY)
                 }
@@ -260,7 +260,7 @@ macro_rules! __impl_public_bitflags {
             }
         }
 
-        __impl_public_bitflags_ops!($PublicBitFlags);
+        __impl_public_bitflags_ops!($BitFlags);
     };
 }
 
@@ -268,8 +268,8 @@ macro_rules! __impl_public_bitflags {
 #[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! __impl_public_bitflags_iter {
-    ($PublicBitFlags:ident) => {
-        impl $PublicBitFlags {
+    ($BitFlags:ident: $T:ty, $PublicBitFlags:ident) => {
+        impl $BitFlags {
             /// Iterate over enabled flag values.
             #[inline]
             pub const fn iter(&self) -> $crate::iter::Iter<$PublicBitFlags> {
@@ -283,8 +283,8 @@ macro_rules! __impl_public_bitflags_iter {
             }
         }
 
-        impl $crate::__private::core::iter::IntoIterator for $PublicBitFlags {
-            type Item = Self;
+        impl $crate::__private::core::iter::IntoIterator for $BitFlags {
+            type Item = $PublicBitFlags;
             type IntoIter = $crate::iter::Iter<$PublicBitFlags>;
 
             fn into_iter(self) -> Self::IntoIter {

--- a/tests/compile-fail/bitflags_custom_bits.rs
+++ b/tests/compile-fail/bitflags_custom_bits.rs
@@ -19,7 +19,7 @@ use std::{
     },
 };
 
-use bitflags::{bitflags, Bits, parser::{ParseError, ParseHex}};
+use bitflags::{bitflags, Bits, parser::{ParseError, WriteHex, ParseHex}};
 
 // Ideally we'd actually want this to work, but currently need something like `num`'s `Zero`
 // With some design work it could be made possible
@@ -120,6 +120,12 @@ impl Binary for MyInt {
 impl ParseHex for MyInt {
     fn parse_hex(input: &str) -> Result<Self, ParseError> {
         Ok(MyInt(u8::from_str_radix(input, 16).map_err(|_| ParseError::invalid_hex_flag(input))?))
+    }
+}
+
+impl WriteHex for MyInt {
+    fn write_hex<W: fmt::Write>(&self, writer: W) -> fmt::Result {
+        LowerHex::fmt(&self.0, writer)
     }
 }
 

--- a/tests/compile-fail/bitflags_custom_bits.rs
+++ b/tests/compile-fail/bitflags_custom_bits.rs
@@ -19,7 +19,7 @@ use std::{
     },
 };
 
-use bitflags::{bitflags, Bits, parser::{ParseError, FromHex}};
+use bitflags::{bitflags, Bits, parser::{ParseError, ParseHex}};
 
 // Ideally we'd actually want this to work, but currently need something like `num`'s `Zero`
 // With some design work it could be made possible
@@ -117,8 +117,8 @@ impl Binary for MyInt {
     }
 }
 
-impl FromHex for MyInt {
-    fn from_hex(input: &str) -> Result<Self, ParseError> {
+impl ParseHex for MyInt {
+    fn parse_hex(input: &str) -> Result<Self, ParseError> {
         Ok(MyInt(u8::from_str_radix(input, 16).map_err(|_| ParseError::invalid_hex_flag(input))?))
     }
 }

--- a/tests/compile-fail/bitflags_custom_bits.stderr
+++ b/tests/compile-fail/bitflags_custom_bits.stderr
@@ -20,6 +20,38 @@ note: required by a bound in `PublicFlags::Primitive`
     |     type Primitive: Primitive;
     |                     ^^^^^^^^^ required by this bound in `PublicFlags::Primitive`
 
+error[E0277]: the trait bound `MyInt: WriteHex` is not satisfied
+   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+    |
+126 | / bitflags! {
+127 | |     struct Flags128: MyInt {
+128 | |         const A = MyInt(0b0000_0001u8);
+129 | |         const B = MyInt(0b0000_0010u8);
+130 | |         const C = MyInt(0b0000_0100u8);
+131 | |     }
+132 | | }
+    | | ^
+    | | |
+    | |_the trait `WriteHex` is not implemented for `MyInt`
+    |   required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `WriteHex`:
+              i128
+              i16
+              i32
+              i64
+              i8
+              isize
+              u128
+              u16
+            and $N others
+note: required by a bound in `to_writer`
+   --> src/parser.rs
+    |
+    |     B::Bits: WriteHex,
+    |              ^^^^^^^^ required by this bound in `to_writer`
+    = note: this error originates in the macro `__impl_internal_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: can't compare `MyInt` with `_` in const contexts
    --> tests/compile-fail/bitflags_custom_bits.rs:126:1
     |

--- a/tests/compile-fail/bitflags_custom_bits.stderr
+++ b/tests/compile-fail/bitflags_custom_bits.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `MyInt: bitflags::traits::Primitive` is not satisfied
-   --> tests/compile-fail/bitflags_custom_bits.rs:127:22
+   --> tests/compile-fail/bitflags_custom_bits.rs:133:22
     |
-127 |     struct Flags128: MyInt {
+133 |     struct Flags128: MyInt {
     |                      ^^^^^ the trait `bitflags::traits::Primitive` is not implemented for `MyInt`
     |
     = help: the following other types implement trait `bitflags::traits::Primitive`:
@@ -20,474 +20,457 @@ note: required by a bound in `PublicFlags::Primitive`
     |     type Primitive: Primitive;
     |                     ^^^^^^^^^ required by this bound in `PublicFlags::Primitive`
 
-error[E0277]: the trait bound `MyInt: WriteHex` is not satisfied
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+error[E0308]: mismatched types
+   --> tests/compile-fail/bitflags_custom_bits.rs:128:32
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
-    | | ^
-    | | |
-    | |_the trait `WriteHex` is not implemented for `MyInt`
-    |   required by a bound introduced by this call
+127 |     fn write_hex<W: fmt::Write>(&self, writer: W) -> fmt::Result {
+    |                  - this type parameter
+128 |         LowerHex::fmt(&self.0, writer)
+    |         -------------          ^^^^^^ expected `&mut Formatter<'_>`, found type parameter `W`
+    |         |
+    |         arguments to this function are incorrect
     |
-    = help: the following other types implement trait `WriteHex`:
-              i128
-              i16
-              i32
-              i64
-              i8
-              isize
-              u128
-              u16
-            and $N others
-note: required by a bound in `to_writer`
-   --> src/parser.rs
-    |
-    |     B::Bits: WriteHex,
-    |              ^^^^^^^^ required by this bound in `to_writer`
-    = note: this error originates in the macro `__impl_internal_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: expected mutable reference `&mut Formatter<'_>`
+                  found type parameter `W`
+note: method defined here
+   --> $RUST/core/src/fmt/mod.rs
 
 error[E0277]: can't compare `MyInt` with `_` in const contexts
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^ no implementation for `MyInt == _`
     |
     = help: the trait `~const PartialEq<_>` is not implemented for `MyInt`
 note: the trait `PartialEq<_>` is implemented for `MyInt`, but that implementation is not `const`
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^
     = note: this error originates in the macro `__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `MyInt` with `_` in const contexts
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^ no implementation for `MyInt == _`
     |
     = help: the trait `~const PartialEq<_>` is not implemented for `MyInt`
 note: the trait `PartialEq<_>` is implemented for `MyInt`, but that implementation is not `const`
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^
     = note: this error originates in the macro `__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `MyInt: BitAnd` is not satisfied
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^ no implementation for `MyInt & MyInt`
     |
     = help: the trait `~const BitAnd` is not implemented for `MyInt`
 note: the trait `BitAnd` is implemented for `MyInt`, but that implementation is not `const`
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^
     = note: this error originates in the macro `__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `MyInt` with `_` in const contexts
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^ no implementation for `MyInt == _`
     |
     = help: the trait `~const PartialEq<_>` is not implemented for `MyInt`
 note: the trait `PartialEq<_>` is implemented for `MyInt`, but that implementation is not `const`
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^
     = note: this error originates in the macro `__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `MyInt: BitOr` is not satisfied
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^ no implementation for `MyInt | MyInt`
     |
     = help: the trait `~const BitOr` is not implemented for `MyInt`
 note: the trait `BitOr` is implemented for `MyInt`, but that implementation is not `const`
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^
     = note: this error originates in the macro `__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `MyInt` with `_` in const contexts
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^ no implementation for `MyInt == _`
     |
     = help: the trait `~const PartialEq<_>` is not implemented for `MyInt`
 note: the trait `PartialEq<_>` is implemented for `MyInt`, but that implementation is not `const`
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^
     = note: this error originates in the macro `__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `MyInt: BitOr` is not satisfied
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^ no implementation for `MyInt | MyInt`
     |
     = help: the trait `~const BitOr` is not implemented for `MyInt`
 note: the trait `BitOr` is implemented for `MyInt`, but that implementation is not `const`
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^
     = note: this error originates in the macro `__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `MyInt` with `_` in const contexts
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^ no implementation for `MyInt == _`
     |
     = help: the trait `~const PartialEq<_>` is not implemented for `MyInt`
 note: the trait `PartialEq<_>` is implemented for `MyInt`, but that implementation is not `const`
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^
     = note: this error originates in the macro `__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `MyInt: BitAnd` is not satisfied
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^ no implementation for `MyInt & MyInt`
     |
     = help: the trait `~const BitAnd` is not implemented for `MyInt`
 note: the trait `BitAnd` is implemented for `MyInt`, but that implementation is not `const`
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^
     = note: this error originates in the macro `__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `MyInt: BitAnd` is not satisfied
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^ no implementation for `MyInt & MyInt`
     |
     = help: the trait `~const BitAnd` is not implemented for `MyInt`
 note: the trait `BitAnd` is implemented for `MyInt`, but that implementation is not `const`
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^
     = note: this error originates in the macro `__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `MyInt` with `_` in const contexts
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^ no implementation for `MyInt == _`
     |
     = help: the trait `~const PartialEq<_>` is not implemented for `MyInt`
 note: the trait `PartialEq<_>` is implemented for `MyInt`, but that implementation is not `const`
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^
     = note: this error originates in the macro `__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `MyInt: BitAnd` is not satisfied
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^ no implementation for `MyInt & MyInt`
     |
     = help: the trait `~const BitAnd` is not implemented for `MyInt`
 note: the trait `BitAnd` is implemented for `MyInt`, but that implementation is not `const`
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^
     = note: this error originates in the macro `__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `MyInt: BitOr` is not satisfied
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^ no implementation for `MyInt | MyInt`
     |
     = help: the trait `~const BitOr` is not implemented for `MyInt`
 note: the trait `BitOr` is implemented for `MyInt`, but that implementation is not `const`
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^
     = note: this error originates in the macro `__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `MyInt: BitAnd` is not satisfied
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^ no implementation for `MyInt & MyInt`
     |
     = help: the trait `~const BitAnd` is not implemented for `MyInt`
 note: the trait `BitAnd` is implemented for `MyInt`, but that implementation is not `const`
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^
     = note: this error originates in the macro `__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `MyInt: Not` is not satisfied
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^ the trait `~const Not` is not implemented for `MyInt`
     |
 note: the trait `Not` is implemented for `MyInt`, but that implementation is not `const`
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^
     = note: this error originates in the macro `__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `MyInt: BitXor` is not satisfied
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^ no implementation for `MyInt ^ MyInt`
     |
     = help: the trait `~const BitXor` is not implemented for `MyInt`
 note: the trait `BitXor` is implemented for `MyInt`, but that implementation is not `const`
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^
     = note: this error originates in the macro `__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `MyInt: Not` is not satisfied
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^ the trait `~const Not` is not implemented for `MyInt`
     |
 note: the trait `Not` is implemented for `MyInt`, but that implementation is not `const`
-   --> tests/compile-fail/bitflags_custom_bits.rs:126:1
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
     |
-126 | / bitflags! {
-127 | |     struct Flags128: MyInt {
-128 | |         const A = MyInt(0b0000_0001u8);
-129 | |         const B = MyInt(0b0000_0010u8);
-130 | |         const C = MyInt(0b0000_0100u8);
-131 | |     }
-132 | | }
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
     | |_^
     = note: this error originates in the macro `__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-pass/bitflags_self_in_value.rs
+++ b/tests/compile-pass/bitflags_self_in_value.rs
@@ -1,0 +1,15 @@
+use bitflags::bitflags;
+
+bitflags! {
+    pub struct Flags: u32 {
+        const SOME_FLAG = 1 << Self::SOME_FLAG_SHIFT;
+    }
+}
+
+impl Flags {
+    const SOME_FLAG_SHIFT: u32 = 5;
+}
+
+fn main() {
+    
+}

--- a/tests/smoke-test/src/main.rs
+++ b/tests/smoke-test/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 use bitflags::bitflags;
 
 bitflags! {


### PR DESCRIPTION
Closes #353 
Closes #356 
Closes #357 

If a flags type refers to `Self` in its definition of flags constants then it may fail to compile because we generate those constants on both the user-facing type and the internally generated one.

I've also rolled `clippy` in CI into this PR and fixed up its associated warnings.