### PR TITLE
Remove html_root_url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "bitflags"
-# NB: When modifying, also modify:
-#   1. html_root_url in lib.rs
-#   2. number in readme (for breaking changes)
+# NB: When modifying, also modify the number in readme (for breaking changes)
 version = "2.3.3"
 edition = "2021"
 rust-version = "1.56.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,7 +423,6 @@
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![cfg_attr(not(test), forbid(unsafe_code))]
 #![cfg_attr(test, allow(mixed_script_confusables))]
-#![doc(html_root_url = "https://docs.rs/bitflags/2.3.3")]
 
 #[doc(inline)]
 pub use traits::{Bits, Flag, Flags};


### PR DESCRIPTION
This is no longer recommended in the API guidelines: https://github.com/rust-lang/api-guidelines/pull/230