### PR TITLE
Add optional binrw/BinRead implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ arbitrary = { version = "1.0", optional = true }
 bytemuck = { version = "1.0", optional = true }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 compiler_builtins = { version = "0.1.2", optional = true }
+binrw = { version = "0.11.2", optional = true }
 
 [dev-dependencies]
 trybuild = "1.0"
@@ -34,6 +35,7 @@ serde_json = "1.0"
 serde_test = "1.0"
 arbitrary = { version = "1.0", features = ["derive"] }
 bytemuck = { version = "1.0", features = ["derive"] }
+binrw = { version = "0.11.2" }
 
 [features]
 std = []

--- a/src/external/binrw_support.rs
+++ b/src/external/binrw_support.rs
@@ -1,0 +1,56 @@
+#[cfg(test)]
+mod tests {
+    use binrw::BinReaderExt;
+
+    pub mod little_endian {
+        bitflags! {
+            #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, binrw::BinRead)]
+            #[br(little)]
+            pub struct ACL: u32 {
+                const Read = 0b0000_0001;
+                const Write = 0b0000_0010;
+                const Execute = 0b0000_0100;
+                const Traverse = 0b0000_1000;
+
+                //const All = Self::Read | Self::Write | Self::Execute | Self::Traverse;
+            }
+        }
+    }
+
+    pub mod big_endian {
+        bitflags! {
+            #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, binrw::BinRead)]
+            #[br(big)]
+            pub struct ACL: u32 {
+                const Read = 0b0000_0001;
+                const Write = 0b0000_0010;
+                const Execute = 0b0000_0100;
+                const Traverse = 0b0000_1000;
+
+               // const All = Self::Read | Self::Write | Self::Execute | Self::Traverse;
+            }
+        }
+    }
+
+    #[test]
+    fn test_binreader_ext_little_endian() {
+        use little_endian::ACL;
+        use std::io::Cursor;
+        let flags = ACL::Read | ACL::Execute;
+        println!("{:?}", flags.bits().to_le_bytes());
+        let buf: [u8; 4] = [0x05, 0x00, 0x00, 0x00];
+        let mut cursor = Cursor::new(&buf[..]);
+        let acl: ACL = cursor.read_ne().unwrap();
+        assert_eq!(acl, ACL::Read | ACL::Execute);
+    }
+
+    #[test]
+    fn test_binreader_ext_big_endian() {
+        use big_endian::ACL;
+        use std::io::Cursor;
+        let buf: [u8; 4] = [0x00, 0x00, 0x00, 0x05];
+        let mut cursor = Cursor::new(&buf[..]);
+        let acl: ACL = cursor.read_ne().unwrap();
+        assert_eq!(acl, ACL::Read | ACL::Execute);
+    }
+}


### PR DESCRIPTION
The goal here is ultimately to teach serde to deserialize raw bitfields from a binary file format, being mindful of the expected endian-ness of the structs. This doesn't get it there from the start, afaik -- but it does seem like a usable starting point.

I don't write a ton of Rust code, so I won't be surprised if this isn't the best way to get this done. Please let me know if there's a better way to do this.