### PR TITLE
Support unnamed flags

### DIFF
--- a/src/example_generated.rs
+++ b/src/example_generated.rs
@@ -21,16 +21,16 @@ __impl_internal_bitflags! {
         // Field `A`.
         ///
         /// This flag has the value `0b00000001`.
-        A = 0b00000001;
+        const A = 0b00000001;
         /// Field `B`.
         ///
         /// This flag has the value `0b00000010`.
-        B = 0b00000010;
+        const B = 0b00000010;
         /// Field `C`.
         ///
         /// This flag has the value `0b00000100`.
-        C = 0b00000100;
-        ABC = Self::A.bits() | Self::B.bits() | Self::C.bits();
+        const C = 0b00000100;
+        const ABC = Self::A.bits() | Self::B.bits() | Self::C.bits();
     }
 }
 
@@ -51,15 +51,15 @@ __impl_public_bitflags_consts! {
         /// Field `A`.
         ///
         /// This flag has the value `0b00000001`.
-        A = 0b00000001;
+        const A = 0b00000001;
         /// Field `B`.
         ///
         /// This flag has the value `0b00000010`.
-        B = 0b00000010;
+        const B = 0b00000010;
         /// Field `C`.
         ///
         /// This flag has the value `0b00000100`.
-        C = 0b00000100;
-        ABC = Self::A.bits() | Self::B.bits() | Self::C.bits();
+        const C = 0b00000100;
+        const ABC = Self::A.bits() | Self::B.bits() | Self::C.bits();
     }
 }

--- a/src/external.rs
+++ b/src/external.rs
@@ -21,8 +21,8 @@ macro_rules! __impl_external_bitflags_my_library {
     (
         $InternalBitFlags:ident: $T:ty, $PublicBitFlags:ident {
             $(
-                $(#[$attr:ident $($args:tt)*])*
-                $Flag:ident;
+                $(#[$inner:ident $($args:tt)*])*
+                const $Flag:tt;
             )*
         }
     ) => {
@@ -37,8 +37,8 @@ macro_rules! __impl_external_bitflags_my_library {
     (
         $InternalBitFlags:ident: $T:ty, $PublicBitFlags:ident {
             $(
-                $(#[$attr:ident $($args:tt)*])*
-                $Flag:ident;
+                $(#[$inner:ident $($args:tt)*])*
+                const $Flag:tt;
             )*
         }
     ) => {};
@@ -57,8 +57,8 @@ Now, we add our macro call to the `__impl_external_bitflags` macro body:
 __impl_external_bitflags_my_library! {
     $InternalBitFlags: $T, $PublicBitFlags {
         $(
-            $(#[$attr $($args)*])*
-            $Flag;
+            $(#[$inner $($args)*])*
+            const $Flag;
         )*
     }
 }
@@ -83,8 +83,8 @@ macro_rules! __impl_external_bitflags {
     (
         $InternalBitFlags:ident: $T:ty, $PublicBitFlags:ident {
             $(
-                $(#[$attr:ident $($args:tt)*])*
-                $Flag:ident;
+                $(#[$inner:ident $($args:tt)*])*
+                const $Flag:tt;
             )*
         }
     ) => {
@@ -95,8 +95,8 @@ macro_rules! __impl_external_bitflags {
         __impl_external_bitflags_serde! {
             $InternalBitFlags: $T, $PublicBitFlags {
                 $(
-                    $(#[$attr $($args)*])*
-                    $Flag;
+                    $(#[$inner $($args)*])*
+                    const $Flag;
                 )*
             }
         }
@@ -104,8 +104,8 @@ macro_rules! __impl_external_bitflags {
         __impl_external_bitflags_arbitrary! {
             $InternalBitFlags: $T, $PublicBitFlags {
                 $(
-                    $(#[$attr $($args)*])*
-                    $Flag;
+                    $(#[$inner $($args)*])*
+                    const $Flag;
                 )*
             }
         }
@@ -113,8 +113,8 @@ macro_rules! __impl_external_bitflags {
         __impl_external_bitflags_bytemuck! {
             $InternalBitFlags: $T, $PublicBitFlags {
                 $(
-                    $(#[$attr $($args)*])*
-                    $Flag;
+                    $(#[$inner $($args)*])*
+                    const $Flag;
                 )*
             }
         }
@@ -132,8 +132,8 @@ macro_rules! __impl_external_bitflags_serde {
     (
         $InternalBitFlags:ident: $T:ty, $PublicBitFlags:ident {
             $(
-                $(#[$attr:ident $($args:tt)*])*
-                $Flag:ident;
+                $(#[$inner:ident $($args:tt)*])*
+                const $Flag:tt;
             )*
         }
     ) => {
@@ -168,8 +168,8 @@ macro_rules! __impl_external_bitflags_serde {
     (
         $InternalBitFlags:ident: $T:ty, $PublicBitFlags:ident {
             $(
-                $(#[$attr:ident $($args:tt)*])*
-                $Flag:ident;
+                $(#[$inner:ident $($args:tt)*])*
+                const $Flag:tt;
             )*
         }
     ) => {};
@@ -189,8 +189,8 @@ macro_rules! __impl_external_bitflags_arbitrary {
     (
             $InternalBitFlags:ident: $T:ty, $PublicBitFlags:ident {
                 $(
-                    $(#[$attr:ident $($args:tt)*])*
-                    $Flag:ident;
+                    $(#[$inner:ident $($args:tt)*])*
+                    const $Flag:tt;
                 )*
             }
     ) => {
@@ -211,8 +211,8 @@ macro_rules! __impl_external_bitflags_arbitrary {
     (
         $InternalBitFlags:ident: $T:ty, $PublicBitFlags:ident {
             $(
-                $(#[$attr:ident $($args:tt)*])*
-                $Flag:ident;
+                $(#[$inner:ident $($args:tt)*])*
+                const $Flag:tt;
             )*
         }
     ) => {};
@@ -226,8 +226,8 @@ macro_rules! __impl_external_bitflags_bytemuck {
     (
         $InternalBitFlags:ident: $T:ty, $PublicBitFlags:ident {
             $(
-                $(#[$attr:ident $($args:tt)*])*
-                $Flag:ident;
+                $(#[$inner:ident $($args:tt)*])*
+                const $Flag:tt;
             )*
         }
     ) => {
@@ -254,8 +254,8 @@ macro_rules! __impl_external_bitflags_bytemuck {
     (
         $InternalBitFlags:ident: $T:ty, $PublicBitFlags:ident {
             $(
-                $(#[$attr:ident $($args:tt)*])*
-                $Flag:ident;
+                $(#[$inner:ident $($args:tt)*])*
+                const $Flag:tt;
             )*
         }
     ) => {};

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -31,8 +31,8 @@ macro_rules! __impl_internal_bitflags {
     (
         $InternalBitFlags:ident: $T:ty, $PublicBitFlags:ident {
             $(
-                $(#[$attr:ident $($args:tt)*])*
-                $Flag:ident = $value:expr;
+                $(#[$inner:ident $($args:tt)*])*
+                const $Flag:tt = $value:expr;
             )*
         }
     ) => {
@@ -100,8 +100,8 @@ macro_rules! __impl_internal_bitflags {
         __impl_public_bitflags! {
             $InternalBitFlags: $T, $PublicBitFlags {
                 $(
-                    $(#[$attr $($args)*])*
-                    $Flag;
+                    $(#[$inner $($args)*])*
+                    const $Flag = $value;
                 )*
             }
         }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -109,6 +109,11 @@ impl<B: Flags> Iterator for IterNames<B> {
 
             self.idx += 1;
 
+            // Skip unnamed flags
+            if flag.name().is_empty() {
+                continue;
+            }
+
             let bits = flag.value().bits();
 
             // If the flag is set in the original source _and_ it has bits that haven't

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,7 +560,7 @@ macro_rules! bitflags {
         $vis:vis struct $BitFlags:ident: $T:ty {
             $(
                 $(#[$inner:ident $($args:tt)*])*
-                const $Flag:ident = $value:expr;
+                const $Flag:tt = $value:expr;
             )*
         }
 
@@ -578,7 +578,7 @@ macro_rules! bitflags {
             $BitFlags: $T {
                 $(
                     $(#[$inner $($args)*])*
-                    $Flag = $value;
+                    const $Flag = $value;
                 )*
             }
         }
@@ -604,7 +604,7 @@ macro_rules! bitflags {
                 InternalBitFlags: $T, $BitFlags {
                     $(
                         $(#[$inner $($args)*])*
-                        $Flag = $value;
+                        const $Flag = $value;
                     )*
                 }
             }
@@ -614,7 +614,7 @@ macro_rules! bitflags {
                 InternalBitFlags: $T, $BitFlags {
                     $(
                         $(#[$inner $($args)*])*
-                        $Flag;
+                        const $Flag;
                     )*
                 }
             }
@@ -640,7 +640,7 @@ macro_rules! bitflags {
         impl $BitFlags:ident: $T:ty {
             $(
                 $(#[$inner:ident $($args:tt)*])*
-                const $Flag:ident = $value:expr;
+                const $Flag:tt = $value:expr;
             )*
         }
 
@@ -650,7 +650,7 @@ macro_rules! bitflags {
             $BitFlags: $T {
                 $(
                     $(#[$inner $($args)*])*
-                    $Flag = $value;
+                    const $Flag = $value;
                 )*
             }
         }
@@ -670,7 +670,7 @@ macro_rules! bitflags {
                 $BitFlags: $T, $BitFlags {
                     $(
                         $(#[$inner $($args)*])*
-                        $Flag;
+                        const $Flag = $value;
                     )*
                 }
             }
@@ -1010,6 +1010,30 @@ macro_rules! __bitflags_expr_safe_attrs {
         $(#[$expr $($exprargs)*])*
         { $e }
     }
+}
+
+/// Implement a flag, which may be a wildcard `_`.
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! __bitflags_flag {
+    (
+        {
+            name: _,
+            named: { $($named:tt)* },
+            unnamed: { $($unnamed:tt)* },
+        }
+    ) => {
+        $($unnamed)*
+    };
+    (
+        {
+            name: $Flag:ident,
+            named: { $($named:tt)* },
+            unnamed: { $($unnamed:tt)* },
+        }
+    ) => {
+        $($named)*
+    };
 }
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,10 +352,9 @@
 //!
 //! ## Multi-bit Flags
 //!
-//! It is allowed to define a flag with multiple bits set, however such
-//! flags are _not_ treated as a set where any of those bits is a valid
-//! flag. Instead, each flag is treated as a unit when converting from
-//! bits with [`from_bits`] or [`from_bits_truncate`].
+//! It is allowed to define a flag with multiple bits set. When using multi-bit flags
+//! with [`from_bits`] or [`from_bits_truncate`], if only a subset of the bits in that flag
+//! are set, the result will still be non-empty:
 //!
 //! ```
 //! use bitflags::bitflags;
@@ -369,8 +368,8 @@
 //!
 //! fn main() {
 //!     // This bit pattern does not set all the bits in `F3`, so it is rejected.
-//!     assert!(Flags::from_bits(0b00000001).is_none());
-//!     assert!(Flags::from_bits_truncate(0b00000001).is_empty());
+//!     assert!(Flags::from_bits(0b00000001).is_some());
+//!     assert!(!Flags::from_bits_truncate(0b00000001).is_empty());
 //! }
 //! ```
 //!

--- a/src/public.rs
+++ b/src/public.rs
@@ -176,49 +176,7 @@ macro_rules! __impl_public_bitflags {
                 }
 
                 fn from_bits_truncate(bits) {
-                    // 3.x: Self(bits & Self::all().bits())
-
-                    let mut truncated = <$T as $crate::Bits>::EMPTY;
-                    let mut i = 0;
-
-                    $(
-                        __bitflags_flag!({
-                            name: $Flag,
-                            named: {
-                                // Treat named flags as "full"
-                                // Only bits from contained flags are retained
-                                __bitflags_expr_safe_attrs!(
-                                    $(#[$inner $($args)*])*
-                                    {{
-                                        let flag = <$PublicBitFlags as $crate::Flags>::FLAGS[i].value().bits();
-
-                                        if flag & bits == flag {
-                                            truncated = truncated | flag;
-                                        }
-
-                                        i += 1;
-                                    }}
-                                );
-                            },
-                            unnamed: {
-                                // Treat unnamed flags as "partial"
-                                // Any intersecting bits are retained
-                                __bitflags_expr_safe_attrs!(
-                                    $(#[$inner $($args)*])*
-                                    {{
-                                        let flag = <$PublicBitFlags as $crate::Flags>::FLAGS[i].value().bits() & bits;
-                                        truncated = truncated | flag;
-
-                                        i += 1;
-                                    }}
-                                );
-                            },
-                        });
-                    )*
-
-                    let _ = bits;
-                    let _ = i;
-                    Self(truncated)
+                    Self(bits & Self::all().bits())
                 }
 
                 fn from_bits_retain(bits) {
@@ -286,22 +244,18 @@ macro_rules! __impl_public_bitflags {
                 }
 
                 fn intersection(f, other) {
-                    // 3.x: Self::from_bits_truncate(f.bits() & other.bits())
                     Self::from_bits_retain(f.bits() & other.bits())
                 }
 
                 fn union(f, other) {
-                    // 3.x: Self::from_bits_truncate(f.bits() & other.bits())
                     Self::from_bits_retain(f.bits() | other.bits())
                 }
 
                 fn difference(f, other) {
-                    // 3.x: Self::from_bits_truncate(f.bits() & other.bits())
                     Self::from_bits_retain(f.bits() & !other.bits())
                 }
 
                 fn symmetric_difference(f, other) {
-                    // 3.x: Self::from_bits_truncate(f.bits() & other.bits())
                     Self::from_bits_retain(f.bits() ^ other.bits())
                 }
 

--- a/src/public.rs
+++ b/src/public.rs
@@ -149,7 +149,9 @@ macro_rules! __impl_public_bitflags {
                         __bitflags_expr_safe_attrs!(
                             $(#[$inner $($args)*])*
                             {{
-                                truncated = truncated | <$PublicBitFlags as $crate::Flags>::FLAGS[i].value().bits();
+                                let flag = <$PublicBitFlags as $crate::Flags>::FLAGS[i].value().bits();
+
+                                truncated = truncated | flag;
                                 i += 1;
                             }}
                         );
@@ -174,7 +176,49 @@ macro_rules! __impl_public_bitflags {
                 }
 
                 fn from_bits_truncate(bits) {
-                    Self(bits & Self::all().bits())
+                    // 3.x: Self(bits & Self::all().bits())
+
+                    let mut truncated = <$T as $crate::Bits>::EMPTY;
+                    let mut i = 0;
+
+                    $(
+                        __bitflags_flag!({
+                            name: $Flag,
+                            named: {
+                                // Treat named flags as "full"
+                                // Only bits from contained flags are retained
+                                __bitflags_expr_safe_attrs!(
+                                    $(#[$inner $($args)*])*
+                                    {{
+                                        let flag = <$PublicBitFlags as $crate::Flags>::FLAGS[i].value().bits();
+
+                                        if flag & bits == flag {
+                                            truncated = truncated | flag;
+                                        }
+
+                                        i += 1;
+                                    }}
+                                );
+                            },
+                            unnamed: {
+                                // Treat unnamed flags as "partial"
+                                // Any intersecting bits are retained
+                                __bitflags_expr_safe_attrs!(
+                                    $(#[$inner $($args)*])*
+                                    {{
+                                        let flag = <$PublicBitFlags as $crate::Flags>::FLAGS[i].value().bits() & bits;
+                                        truncated = truncated | flag;
+
+                                        i += 1;
+                                    }}
+                                );
+                            },
+                        });
+                    )*
+
+                    let _ = bits;
+                    let _ = i;
+                    Self(truncated)
                 }
 
                 fn from_bits_retain(bits) {
@@ -242,18 +286,22 @@ macro_rules! __impl_public_bitflags {
                 }
 
                 fn intersection(f, other) {
+                    // 3.x: Self::from_bits_truncate(f.bits() & other.bits())
                     Self::from_bits_retain(f.bits() & other.bits())
                 }
 
                 fn union(f, other) {
+                    // 3.x: Self::from_bits_truncate(f.bits() & other.bits())
                     Self::from_bits_retain(f.bits() | other.bits())
                 }
 
                 fn difference(f, other) {
+                    // 3.x: Self::from_bits_truncate(f.bits() & other.bits())
                     Self::from_bits_retain(f.bits() & !other.bits())
                 }
 
                 fn symmetric_difference(f, other) {
+                    // 3.x: Self::from_bits_truncate(f.bits() & other.bits())
                     Self::from_bits_retain(f.bits() ^ other.bits())
                 }
 

--- a/src/public.rs
+++ b/src/public.rs
@@ -150,11 +150,12 @@ macro_rules! __impl_public_bitflags {
                             $(#[$inner $($args)*])*
                             {{
                                 truncated = truncated | <$PublicBitFlags as $crate::Flags>::FLAGS[i].value().bits();
-                                i +=1 ;
+                                i += 1;
                             }}
                         );
                     )*
 
+                    let _ = i;
                     Self::from_bits_retain(truncated)
                 }
 
@@ -241,19 +242,19 @@ macro_rules! __impl_public_bitflags {
                 }
 
                 fn intersection(f, other) {
-                    Self::from_bits_truncate(f.bits() & other.bits())
+                    Self::from_bits_retain(f.bits() & other.bits())
                 }
 
                 fn union(f, other) {
-                    Self::from_bits_truncate(f.bits() | other.bits())
+                    Self::from_bits_retain(f.bits() | other.bits())
                 }
 
                 fn difference(f, other) {
-                    Self::from_bits_truncate(f.bits() & !other.bits())
+                    Self::from_bits_retain(f.bits() & !other.bits())
                 }
 
                 fn symmetric_difference(f, other) {
-                    Self::from_bits_truncate(f.bits() ^ other.bits())
+                    Self::from_bits_retain(f.bits() ^ other.bits())
                 }
 
                 fn complement(f) {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -116,6 +116,9 @@ bitflags! {
         /// 1 << 2
         const C = 1 << 2;
 
+        /// 1 | (1 << 1) | (1 << 2)
+        const ABC = Self::A.bits() | Self::B.bits() | Self::C.bits();
+
         /// External
         const _ = !0;
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -122,4 +122,10 @@ bitflags! {
         /// External
         const _ = !0;
     }
+
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+    pub struct TestExternalFull: u8 {
+        /// External
+        const _ = !0;
+    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -104,4 +104,19 @@ bitflags! {
         /// 2
         const D = 1 << 1;
     }
+
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+    pub struct TestExternal: u8 {
+        /// 1
+        const A = 1;
+
+        /// 1 << 1
+        const B = 1 << 1;
+
+        /// 1 << 2
+        const C = 1 << 2;
+
+        /// External
+        const _ = !0;
+    }
 }

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -9,6 +9,8 @@ fn cases() {
     case(0, TestZero::all);
 
     case(0, TestEmpty::all);
+
+    case(!0, TestExternal::all);
 }
 
 #[track_caller]

--- a/src/tests/bits.rs
+++ b/src/tests/bits.rs
@@ -16,7 +16,11 @@ fn cases() {
 
     case(1 << 3, TestEmpty::from_bits_retain(1 << 3), TestEmpty::bits);
 
-    case(1 << 4 | 1 << 6, TestExternal::from_bits_retain(1 << 4 | 1 << 6), TestExternal::bits);
+    case(
+        1 << 4 | 1 << 6,
+        TestExternal::from_bits_retain(1 << 4 | 1 << 6),
+        TestExternal::bits,
+    );
 }
 
 #[track_caller]

--- a/src/tests/bits.rs
+++ b/src/tests/bits.rs
@@ -15,6 +15,8 @@ fn cases() {
     case(1 << 3, TestZero::from_bits_retain(1 << 3), TestZero::bits);
 
     case(1 << 3, TestEmpty::from_bits_retain(1 << 3), TestEmpty::bits);
+
+    case(1 << 4 | 1 << 6, TestExternal::from_bits_retain(1 << 4 | 1 << 6), TestExternal::bits);
 }
 
 #[track_caller]

--- a/src/tests/complement.rs
+++ b/src/tests/complement.rs
@@ -29,8 +29,7 @@ fn cases() {
 
     case(0, TestEmpty::empty(), TestEmpty::complement);
 
-    // Complement doesn't detect overlapping bits in multi-bit flags
-    case(0, TestOverlapping::AB, TestOverlapping::complement);
+    case(1 << 2, TestOverlapping::AB, TestOverlapping::complement);
 
     case(!0, TestExternal::empty(), TestExternal::complement);
 }

--- a/src/tests/complement.rs
+++ b/src/tests/complement.rs
@@ -31,6 +31,8 @@ fn cases() {
 
     // Complement doesn't detect overlapping bits in multi-bit flags
     case(0, TestOverlapping::AB, TestOverlapping::complement);
+
+    case(!0, TestExternal::empty(), TestExternal::complement);
 }
 
 #[track_caller]

--- a/src/tests/contains.rs
+++ b/src/tests/contains.rs
@@ -70,6 +70,17 @@ fn cases() {
         ],
         TestOverlapping::contains,
     );
+
+    case(
+        TestExternal::all(),
+        &[
+            (TestExternal::A, true),
+            (TestExternal::B, true),
+            (TestExternal::C, true),
+            (TestExternal::from_bits_retain(1 << 5 | 1 << 7), true),
+        ],
+        TestExternal::contains,
+    );
 }
 
 #[track_caller]

--- a/src/tests/difference.rs
+++ b/src/tests/difference.rs
@@ -25,9 +25,7 @@ fn cases() {
 
     case(
         TestExternal::from_bits_retain(!0),
-        &[
-            (TestExternal::A, 0b1111_1110),
-        ],
+        &[(TestExternal::A, 0b1111_1110)],
         TestExternal::difference,
     );
 
@@ -46,8 +44,6 @@ fn cases() {
         1 << 1 | 1 << 2,
         (TestFlags::from_bits_retain(!0) & !TestFlags::A).bits()
     );
-
-
 }
 
 #[track_caller]

--- a/src/tests/difference.rs
+++ b/src/tests/difference.rs
@@ -23,6 +23,19 @@ fn cases() {
         TestFlags::difference,
     );
 
+    case(
+        TestExternal::from_bits_retain(!0),
+        &[
+            (TestExternal::A, 0b1111_1110),
+        ],
+        TestExternal::difference,
+    );
+
+    assert_eq!(
+        0b1111_1110,
+        (TestExternal::from_bits_retain(!0) & !TestExternal::A).bits()
+    );
+
     assert_eq!(
         0b1111_1110,
         (TestFlags::from_bits_retain(!0).difference(TestFlags::A)).bits()
@@ -33,6 +46,8 @@ fn cases() {
         1 << 1 | 1 << 2,
         (TestFlags::from_bits_retain(!0) & !TestFlags::A).bits()
     );
+
+
 }
 
 #[track_caller]

--- a/src/tests/empty.rs
+++ b/src/tests/empty.rs
@@ -9,6 +9,8 @@ fn cases() {
     case(0, TestZero::empty);
 
     case(0, TestEmpty::empty);
+
+    case(0, TestExternal::empty);
 }
 
 #[track_caller]

--- a/src/tests/extend.rs
+++ b/src/tests/extend.rs
@@ -16,3 +16,24 @@ fn cases() {
 
     assert_eq!(TestFlags::ABC | TestFlags::from_bits_retain(1 << 5), flags);
 }
+
+mod external {
+    use super::*;
+
+    #[test]
+    fn cases() {
+        let mut flags = TestExternal::empty();
+
+        flags.extend(TestExternal::A);
+
+        assert_eq!(TestExternal::A, flags);
+
+        flags.extend(TestExternal::A | TestExternal::B | TestExternal::C);
+
+        assert_eq!(TestExternal::ABC, flags);
+
+        flags.extend(TestExternal::from_bits_retain(1 << 5));
+
+        assert_eq!(TestExternal::ABC | TestExternal::from_bits_retain(1 << 5), flags);
+    }
+}

--- a/src/tests/extend.rs
+++ b/src/tests/extend.rs
@@ -34,6 +34,9 @@ mod external {
 
         flags.extend(TestExternal::from_bits_retain(1 << 5));
 
-        assert_eq!(TestExternal::ABC | TestExternal::from_bits_retain(1 << 5), flags);
+        assert_eq!(
+            TestExternal::ABC | TestExternal::from_bits_retain(1 << 5),
+            flags
+        );
     }
 }

--- a/src/tests/flags.rs
+++ b/src/tests/flags.rs
@@ -21,3 +21,26 @@ fn cases() {
 
     assert_eq!(0, TestEmpty::FLAGS.iter().count());
 }
+
+mod external {
+    use super::*;
+
+    #[test]
+    fn cases() {
+        let flags = TestExternal::FLAGS
+            .iter()
+            .map(|flag| (flag.name(), flag.value().bits()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            vec![
+                ("A", 1u8),
+                ("B", 1 << 1),
+                ("C", 1 << 2),
+                ("ABC", 1 | 1 << 1 | 1 << 2),
+                ("", !0),
+            ],
+            flags,
+        );
+    }
+}

--- a/src/tests/fmt.rs
+++ b/src/tests/fmt.rs
@@ -49,6 +49,33 @@ fn cases() {
         "2",
         "10",
     );
+
+    case(
+        TestExternal::from_bits_retain(1 | 1 << 1 | 1 << 3),
+        "TestExternal(A | B | 0x8)",
+        "B",
+        "b",
+        "13",
+        "1011",
+    );
+
+    case(
+        TestExternal::all(),
+        "TestExternal(A | B | C | 0xf8)",
+        "FF",
+        "ff",
+        "377",
+        "11111111",
+    );
+
+    case(
+        TestExternalFull::all(),
+        "TestExternalFull(0xff)",
+        "FF",
+        "ff",
+        "377",
+        "11111111",
+    );
 }
 
 #[track_caller]

--- a/src/tests/from_bits.rs
+++ b/src/tests/from_bits.rs
@@ -17,7 +17,9 @@ fn cases() {
 
     case(Some(1 | 1 << 1), 1 | 1 << 1, TestOverlapping::from_bits);
 
-    case(None, 1 << 1, TestOverlapping::from_bits);
+    case(Some(1 << 1), 1 << 1, TestOverlapping::from_bits);
+
+    case(Some(1 << 5), 1 << 5, TestExternal::from_bits);
 }
 
 #[track_caller]

--- a/src/tests/from_bits_retain.rs
+++ b/src/tests/from_bits_retain.rs
@@ -14,6 +14,8 @@ fn cases() {
     case(1 | 1 << 1, TestOverlapping::from_bits_retain);
 
     case(1 << 1, TestOverlapping::from_bits_retain);
+
+    case(1 << 5, TestExternal::from_bits_retain);
 }
 
 #[track_caller]

--- a/src/tests/from_bits_truncate.rs
+++ b/src/tests/from_bits_truncate.rs
@@ -17,7 +17,9 @@ fn cases() {
 
     case(1 | 1 << 1, 1 | 1 << 1, TestOverlapping::from_bits_truncate);
 
-    case(0, 1 << 1, TestOverlapping::from_bits_truncate);
+    case(1 << 1, 1 << 1, TestOverlapping::from_bits_truncate);
+
+    case(1 << 5, 1 << 5, TestExternal::from_bits_truncate);
 }
 
 #[track_caller]

--- a/src/tests/from_name.rs
+++ b/src/tests/from_name.rs
@@ -16,6 +16,10 @@ fn cases() {
     case(Some(0), "ZERO", TestZero::from_name);
 
     case(Some(2), "二", TestUnicode::from_name);
+
+    case(None, "_", TestExternal::from_name);
+
+    case(None, "", TestExternal::from_name);
 }
 
 #[track_caller]

--- a/src/tests/iter.rs
+++ b/src/tests/iter.rs
@@ -13,6 +13,14 @@ fn roundtrip() {
                 TestFlags::from_bits_truncate(f.bits()),
                 f.iter_names().map(|(_, f)| f).collect::<TestFlags>()
             );
+
+            let f = TestExternal::from_bits_retain(a | b);
+
+            assert_eq!(f, f.iter().collect::<TestExternal>());
+            assert_eq!(
+                TestExternal::from_bits_truncate(f.bits()),
+                f.iter_names().map(|(_, f)| f).collect::<TestExternal>()
+            );
         }
     }
 }
@@ -44,6 +52,18 @@ mod collect {
             .into_iter()
             .collect::<TestFlags>()
             .bits()
+        );
+
+        assert_eq!(
+            1 << 5 | 1 << 7,
+            [
+                TestExternal::empty(),
+                TestExternal::from_bits_retain(1 << 5),
+                TestExternal::from_bits_retain(1 << 7),
+            ]
+                .into_iter()
+                .collect::<TestExternal>()
+                .bits()
         );
     }
 }
@@ -77,6 +97,8 @@ mod iter {
         );
 
         case(&[], TestZero::ZERO, TestZero::iter);
+
+        case(&[1, 1 << 1, 1 << 2, 0b1111_1000], TestExternal::all(), TestExternal::iter);
     }
 
     #[track_caller]

--- a/src/tests/iter.rs
+++ b/src/tests/iter.rs
@@ -17,10 +17,6 @@ fn roundtrip() {
             let f = TestExternal::from_bits_retain(a | b);
 
             assert_eq!(f, f.iter().collect::<TestExternal>());
-            assert_eq!(
-                TestExternal::from_bits_truncate(f.bits()),
-                f.iter_names().map(|(_, f)| f).collect::<TestExternal>()
-            );
         }
     }
 }
@@ -61,9 +57,9 @@ mod collect {
                 TestExternal::from_bits_retain(1 << 5),
                 TestExternal::from_bits_retain(1 << 7),
             ]
-                .into_iter()
-                .collect::<TestExternal>()
-                .bits()
+            .into_iter()
+            .collect::<TestExternal>()
+            .bits()
         );
     }
 }
@@ -98,7 +94,11 @@ mod iter {
 
         case(&[], TestZero::ZERO, TestZero::iter);
 
-        case(&[1, 1 << 1, 1 << 2, 0b1111_1000], TestExternal::all(), TestExternal::iter);
+        case(
+            &[1, 1 << 1, 1 << 2, 0b1111_1000],
+            TestExternal::all(),
+            TestExternal::iter,
+        );
     }
 
     #[track_caller]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -63,10 +63,6 @@ pub trait Flags: Sized + 'static {
 
     /// Convert from underlying bit representation, unless that
     /// representation contains bits that do not correspond to a flag.
-    ///
-    /// Note that each [multi-bit flag] is treated as a unit for this comparison.
-    ///
-    /// [multi-bit flag]: index.html#multi-bit-flags
     fn from_bits(bits: Self::Bits) -> Option<Self> {
         let truncated = Self::from_bits_truncate(bits);
 
@@ -79,10 +75,6 @@ pub trait Flags: Sized + 'static {
 
     /// Convert from underlying bit representation, dropping any bits
     /// that do not correspond to flags.
-    ///
-    /// Note that each [multi-bit flag] is treated as a unit for this comparison.
-    ///
-    /// [multi-bit flag]: index.html#multi-bit-flags
     fn from_bits_truncate(bits: Self::Bits) -> Self {
         Self::from_bits_retain(bits & Self::all().bits())
     }
@@ -189,26 +181,26 @@ pub trait Flags: Sized + 'static {
     /// Returns the intersection between the flags in `self` and `other`.
     #[must_use]
     fn intersection(self, other: Self) -> Self {
-        Self::from_bits_truncate(self.bits() & other.bits())
+        Self::from_bits_retain(self.bits() & other.bits())
     }
 
     /// Returns the union of between the flags in `self` and `other`.
     #[must_use]
     fn union(self, other: Self) -> Self {
-        Self::from_bits_truncate(self.bits() | other.bits())
+        Self::from_bits_retain(self.bits() | other.bits())
     }
 
     /// Returns the difference between the flags in `self` and `other`.
     #[must_use]
     fn difference(self, other: Self) -> Self {
-        Self::from_bits_truncate(self.bits() & !other.bits())
+        Self::from_bits_retain(self.bits() & !other.bits())
     }
 
     /// Returns the symmetric difference between the flags
     /// in `self` and `other`.
     #[must_use]
     fn symmetric_difference(self, other: Self) -> Self {
-        Self::from_bits_truncate(self.bits() ^ other.bits())
+        Self::from_bits_retain(self.bits() ^ other.bits())
     }
 
     /// Returns the complement of this set of flags.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -76,28 +76,7 @@ pub trait Flags: Sized + 'static {
     /// Convert from underlying bit representation, dropping any bits
     /// that do not correspond to flags.
     fn from_bits_truncate(bits: Self::Bits) -> Self {
-        // 3.x: Self::from_bits_retain(bits & Self::all().bits())
-        let mut truncated = Self::Bits::EMPTY;
-
-        for flag in Self::FLAGS.iter() {
-            // Treat named flags as "full"
-            // Only bits from contained flags are retained
-            if !flag.name.is_empty() {
-                let flag = flag.value().bits();
-
-                if flag & bits == flag {
-                    truncated = truncated | flag;
-                }
-            }
-            // Treat unnamed flags as "partial"
-            // Any intersecting bits are retained
-            else {
-                let flag = flag.value().bits() & bits;
-                truncated = truncated | flag;
-            }
-        }
-
-        Self::from_bits_retain(truncated)
+        Self::from_bits_retain(bits & Self::all().bits())
     }
 
     /// Convert from underlying bit representation, preserving all
@@ -203,21 +182,18 @@ pub trait Flags: Sized + 'static {
     /// Returns the intersection between the flags in `self` and `other`.
     #[must_use]
     fn intersection(self, other: Self) -> Self {
-        // 3.x: Self::from_bits_truncate(self.bits() & other.bits())
         Self::from_bits_retain(self.bits() & other.bits())
     }
 
     /// Returns the union of between the flags in `self` and `other`.
     #[must_use]
     fn union(self, other: Self) -> Self {
-        // 3.x: Self::from_bits_truncate(self.bits() | other.bits())
         Self::from_bits_retain(self.bits() | other.bits())
     }
 
     /// Returns the difference between the flags in `self` and `other`.
     #[must_use]
     fn difference(self, other: Self) -> Self {
-        // 3.x: Self::from_bits_truncate(self.bits() & !other.bits())
         Self::from_bits_retain(self.bits() & !other.bits())
     }
 
@@ -225,7 +201,6 @@ pub trait Flags: Sized + 'static {
     /// in `self` and `other`.
     #[must_use]
     fn symmetric_difference(self, other: Self) -> Self {
-        // 3.x: Self::from_bits_truncate(self.bits() ^ other.bits())
         Self::from_bits_retain(self.bits() ^ other.bits())
     }
 

--- a/tests/compile-fail/bitflags_missing_value.stderr
+++ b/tests/compile-fail/bitflags_missing_value.stderr
@@ -7,8 +7,8 @@ error: no rules expected the token `;`
 note: while trying to match `=`
  --> src/lib.rs
   |
-  |                 const $Flag:ident = $value:expr;
-  |                                   ^
+  |                 const $Flag:tt = $value:expr;
+  |                                ^
 
 error[E0601]: `main` function not found in crate `$CRATE`
  --> tests/compile-fail/bitflags_missing_value.rs:8:2

--- a/tests/compile-fail/unnamed_const.rs
+++ b/tests/compile-fail/unnamed_const.rs
@@ -1,0 +1,11 @@
+use bitflags::bitflags;
+
+bitflags! {
+    pub struct Unnamed: u8 {
+        const _ = 1;
+
+        const A = Self::_.bits();
+    }
+}
+
+fn main() {}

--- a/tests/compile-fail/unnamed_const.stderr
+++ b/tests/compile-fail/unnamed_const.stderr
@@ -1,0 +1,21 @@
+error: expected identifier, found reserved identifier `_`
+ --> tests/compile-fail/unnamed_const.rs:7:25
+  |
+7 |         const A = Self::_.bits();
+  |                         ^ expected identifier, found reserved identifier
+
+error[E0599]: no associated item named `_` found for struct `Unnamed` in the current scope
+ --> tests/compile-fail/unnamed_const.rs:7:25
+  |
+3 | / bitflags! {
+4 | |     pub struct Unnamed: u8 {
+5 | |         const _ = 1;
+6 | |
+7 | |         const A = Self::_.bits();
+  | |                         ^
+  | |                         |
+  | |                         associated item not found in `Unnamed`
+  | |                         help: there is an associated constant with a similar name: `A`
+8 | |     }
+9 | | }
+  | |_- associated item `_` not found for this struct

--- a/tests/compile-pass/unnamed.rs
+++ b/tests/compile-pass/unnamed.rs
@@ -8,6 +8,10 @@ bitflags! {
         const _ = 2;
         const _ = !0;
     }
+
+    pub struct External: u8 {
+        const _ = !0;
+    }
 }
 
 fn main() {}

--- a/tests/compile-pass/unnamed.rs
+++ b/tests/compile-pass/unnamed.rs
@@ -1,0 +1,13 @@
+use bitflags::bitflags;
+
+bitflags! {
+    pub struct Unnamed: u8 {
+        const A = 1;
+
+        const _ = Self::A.bits();
+        const _ = 2;
+        const _ = !0;
+    }
+}
+
+fn main() {}

--- a/tests/compile-pass/unnamed.rs
+++ b/tests/compile-pass/unnamed.rs
@@ -12,6 +12,12 @@ bitflags! {
     pub struct External: u8 {
         const _ = !0;
     }
+
+    pub struct Overlapping: u8 {
+        const _ = 1;
+        const _ = 2;
+        const _ = !0;
+    }
 }
 
 fn main() {}

--- a/tests/smoke-test/Cargo.toml
+++ b/tests/smoke-test/Cargo.toml
@@ -6,4 +6,3 @@ publish = false
 
 [dependencies.bitflags]
 path = "../../"
-all-features = true

--- a/tests/smoke-test/Cargo.toml
+++ b/tests/smoke-test/Cargo.toml
@@ -6,3 +6,4 @@ publish = false
 
 [dependencies.bitflags]
 path = "../../"
+all-features = true

--- a/tests/smoke-test/src/main.rs
+++ b/tests/smoke-test/src/main.rs
@@ -9,6 +9,8 @@ bitflags! {
         const B = 0b00000010;
         const C = 0b00000100;
         const ABC = Flags::A.bits() | Flags::B.bits() | Flags::C.bits();
+
+        const _ = !0;
     }
 }
 


### PR DESCRIPTION
This PR introduces the concept of _unnamed flags_. You can add an unnamed flag to your flags types like:

```rust
bitflags! {
    pub struct Flags: u8 {
        // regular, named flag
        const A = 1;

        // unnamed flag
        const _ = !0;
    }
}
```

Adding an unnamed flag means its bits will be part of the mask in `from_bits_truncate`, but it won't generate a constant, and it won't be given a name when formatting or parsing.