### PR TITLE
allow clippy::bad_bit_mask in generated Debug impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,6 +455,7 @@ macro_rules! __impl_bitflags {
                     $(
                         __impl_bitflags! {
                             #[allow(deprecated)]
+                            #[allow(clippy::bad_bit_mask)]
                             #[inline]
                             $(? #[$attr $($args)*])*
                             fn $Flag(&self) -> bool {


### PR DESCRIPTION
Nightly clippy seems to have learned to be able to see 0 values in fields of const structs. This is causing a bunch of warnings in bitflags usages which have consts defined as 0.

I only see this issue on the 1.0 branch.

Example reproducing the issue:

```rust
use bitflags::bitflags;

bitflags! {
    struct Foo : u32 {
        const BAR = 0;
    }
}

fn main() {
    let f = Foo::BAR;
    dbg!(f);
}
```