### PR TITLE
Update smoke test to verify all Clippy and rustc lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -590,7 +590,9 @@ macro_rules! bitflags {
             unused_mut,
             unused_imports,
             non_upper_case_globals,
-            clippy::assign_op_pattern
+            clippy::assign_op_pattern,
+            clippy::indexing_slicing,
+            clippy::same_name_method
         )]
         const _: () = {
             // Declared in a "hidden" scope that can't be reached directly

--- a/tests/smoke-test/src/main.rs
+++ b/tests/smoke-test/src/main.rs
@@ -1,19 +1,66 @@
-#![deny(warnings)]
+#![allow(unknown_lints)]
+#![deny(clippy::all, clippy::pedantic, clippy::restriction)]
+#![allow(clippy::blanket_clippy_restriction_lints)]
+// deny all rustc's built-in lints
+#![deny(
+    warnings,
+    future_incompatible,
+    let_underscore,
+    nonstandard_style,
+    rust_2018_compatibility,
+    rust_2018_idioms,
+    rust_2021_compatibility,
+    unused
+)]
+// deny additional allow by default from rustc
+#![deny(
+    deprecated_in_future,
+    ffi_unwind_calls,
+    macro_use_extern_crate,
+    meta_variable_misuse,
+    missing_abi,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    missing_docs,
+    non_ascii_idents,
+    noop_method_call,
+    single_use_lifetimes,
+    trivial_casts,
+    trivial_numeric_casts,
+    unreachable_pub,
+    unsafe_code,
+    unsafe_op_in_unsafe_fn,
+    unused_crate_dependencies,
+    unused_import_braces,
+    unused_lifetimes,
+    unused_qualifications,
+    unused_results,
+    unused_tuple_struct_fields,
+    variant_size_differences
+)]
+
+//! An example file for smoke tests
 
 use bitflags::bitflags;
 
 bitflags! {
     #[derive(Debug)]
+    /// Example Flags
     pub struct Flags: u32 {
-        const A = 0b00000001;
-        const B = 0b00000010;
-        const C = 0b00000100;
+        /// A
+        const A = 0b0000_0001;
+        /// B
+        const B = 0b0000_0010;
+        /// C
+        const C = 0b0000_0100;
+        /// ABC
         const ABC = Flags::A.bits() | Flags::B.bits() | Flags::C.bits();
 
         const _ = !0;
     }
 }
 
+#[allow(clippy::print_stdout, clippy::use_debug)]
 fn main() {
     println!("{:?}", Flags::ABC);
 }


### PR DESCRIPTION
## Why

Different projects will have different combinations of rustc and Clippy lints enabled, including lints from the `clippy::restriction` and `clippy::pedantic` groups, that are allowed by default. This results in a situation where users of bitflags, depending on their configuration, will have linting errors that they are unable to easily resolve.

## What

This updates the smoke test to include all lints from Clippy rustc, that are allowed by default. This allows CI to verify that any changes to bitflags that would result in a failing lint can be caught immediately.

The Clippy lints can be enabled in bulk, since all the lints are contained within one of a small set of rather stable groups. The rustc lints, however, are more difficult, as there are several lints that are not included in any group. As far as I am aware, there is not a way to enable all lint using something like `deny(allows)`, or similar.

## Justification

I started making this change because I have `clippy::same_name_method` enabled in a project, which was causing bitflags to fail. Once I had addressed that particular issue in a local copy, I had issues with `clippy::indexing_slicing` failing in a different project.

From there I decided to test is there were any further errors, and this was the end result. I decided to not include `clippy::cargo` as they should never be a problem, and `clippy::nursery` as those rules often have many false positives.

There are two drawbacks to this approach. The first is that the "list" of lints (particularly from rustc) will need to be maintained as new lints are added. I do not think this will be too much of a burden when compared to the effort of addressing linting issues from users, and not having the lints listed is the current state.

The second drawback, is that as new lints are added to the groups denied for Clippy or rustc, new changes may require additional allowed lints. However, not addressing these lints could result in breaking projects that use bitflags.