### PR TITLE
Prepare for 2.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 2.4.0
+
+## What's Changed
+* Remove html_root_url by @eldruin in https://github.com/bitflags/bitflags/pull/368
+* Support unnamed flags by @KodrAus in https://github.com/bitflags/bitflags/pull/371
+* Update smoke test to verify all Clippy and rustc lints by @MitMaro in https://github.com/bitflags/bitflags/pull/374
+* Specify the behavior of bitflags by @KodrAus in https://github.com/bitflags/bitflags/pull/369
+
+## New Contributors
+* @eldruin made their first contribution in https://github.com/bitflags/bitflags/pull/368
+* @MitMaro made their first contribution in https://github.com/bitflags/bitflags/pull/374
+
+**Full Changelog**: https://github.com/bitflags/bitflags/compare/2.3.3...2.4.0
+
 # 2.3.3
 
 ## Changes to `-=`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitflags"
 # NB: When modifying, also modify the number in readme (for breaking changes)
-version = "2.3.3"
+version = "2.4.0"
 edition = "2021"
 rust-version = "1.56.0"
 authors = ["The Rust Project Developers"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bitflags = "2.3.3"
+bitflags = "2.4.0"
 ```
 
 and this to your source code:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ Add `bitflags` to your `Cargo.toml`:
 
 ```toml
 [dependencies.bitflags]
-version = "2.3.3"
+version = "2.4.0"
 ```
 
 ## Generating flags types


### PR DESCRIPTION
## What's Changed
* Remove html_root_url by @eldruin in https://github.com/bitflags/bitflags/pull/368
* Support unnamed flags by @KodrAus in https://github.com/bitflags/bitflags/pull/371
* Update smoke test to verify all Clippy and rustc lints by @MitMaro in https://github.com/bitflags/bitflags/pull/374
* Specify the behavior of bitflags by @KodrAus in https://github.com/bitflags/bitflags/pull/369

## New Contributors
* @eldruin made their first contribution in https://github.com/bitflags/bitflags/pull/368
* @MitMaro made their first contribution in https://github.com/bitflags/bitflags/pull/374