### PR TITLE
Cargo.toml: Anchor excludes to root of the package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["no-std"]
 description = """
 A macro to generate structures which behave like bitflags.
 """
-exclude = ["tests", ".github"]
+exclude = ["/tests", "/.github"]
 
 [dependencies]
 serde = { version = "1.0", optional = true, default-features = false }


### PR DESCRIPTION
Without anchoring the excludes, src/tests/ is missing from the published
crate.  This causes “cargo test” to fail because code referenced by
src/tests.rs is not present.

---
This is important for distributors, like Debian, who build their
packages from the crate rather than the VCS.  Our own CI is currently
failing for bitflags due to this.  We can disable the tests for now, but
it would be helpful to be able to run them.