### PR TITLE
Add support for impl mode structs to be repr(packed)

### DIFF
--- a/src/public.rs
+++ b/src/public.rs
@@ -321,7 +321,8 @@ macro_rules! __impl_public_bitflags_ops {
                 &self,
                 f: &mut $crate::__private::core::fmt::Formatter,
             ) -> $crate::__private::core::fmt::Result {
-                $crate::__private::core::fmt::Binary::fmt(&self.0, f)
+                let inner = self.0;
+                $crate::__private::core::fmt::Binary::fmt(&inner, f)
             }
         }
 
@@ -330,7 +331,8 @@ macro_rules! __impl_public_bitflags_ops {
                 &self,
                 f: &mut $crate::__private::core::fmt::Formatter,
             ) -> $crate::__private::core::fmt::Result {
-                $crate::__private::core::fmt::Octal::fmt(&self.0, f)
+                let inner = self.0;
+                $crate::__private::core::fmt::Octal::fmt(&inner, f)
             }
         }
 
@@ -339,7 +341,8 @@ macro_rules! __impl_public_bitflags_ops {
                 &self,
                 f: &mut $crate::__private::core::fmt::Formatter,
             ) -> $crate::__private::core::fmt::Result {
-                $crate::__private::core::fmt::LowerHex::fmt(&self.0, f)
+                let inner = self.0;
+                $crate::__private::core::fmt::LowerHex::fmt(&inner, f)
             }
         }
 
@@ -348,7 +351,8 @@ macro_rules! __impl_public_bitflags_ops {
                 &self,
                 f: &mut $crate::__private::core::fmt::Formatter,
             ) -> $crate::__private::core::fmt::Result {
-                $crate::__private::core::fmt::UpperHex::fmt(&self.0, f)
+                let inner = self.0;
+                $crate::__private::core::fmt::UpperHex::fmt(&inner, f)
             }
         }
 

--- a/tests/compile-pass/bitflags_impl_repr_packed.rs
+++ b/tests/compile-pass/bitflags_impl_repr_packed.rs
@@ -1,0 +1,13 @@
+extern crate bitflags;
+
+#[repr(packed)]
+struct Example(u64);
+
+bitflags::bitflags! {
+    impl Example: u64 {
+        const FLAG_1 = 0b01;
+        const FLAG_2 = 0b10;
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
This allows the following code to compile, with the only downside being a possible copy of the internal value for non-packed types, although I'm somewhat certain that would be optimised out.
```rs
#[repr(packed)]
struct Example(u64);

bitflags::bitflags! {
    impl Example: u64 {
        ...
    }
}
```