### PR TITLE
Delete use of `local_inner_macros`

### DIFF
--- a/src/external.rs
+++ b/src/external.rs
@@ -14,7 +14,7 @@ Next, re-export the library from the `__private` module here.
 Next, define a macro like so:
 
 ```rust
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 #[cfg(feature = "serde")]
 macro_rules! __impl_external_bitflags_my_library {
@@ -30,7 +30,7 @@ macro_rules! __impl_external_bitflags_my_library {
     };
 }
 
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 #[cfg(not(feature = "my_library"))]
 macro_rules! __impl_external_bitflags_my_library {
@@ -77,7 +77,7 @@ pub(crate) mod __private {
 }
 
 /// Implements traits from external libraries for the internal bitflags type.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 macro_rules! __impl_external_bitflags {
     (
@@ -125,7 +125,7 @@ macro_rules! __impl_external_bitflags {
 pub mod serde;
 
 /// Implement `Serialize` and `Deserialize` for the internal bitflags type.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 #[cfg(feature = "serde")]
 macro_rules! __impl_external_bitflags_serde {
@@ -161,7 +161,7 @@ macro_rules! __impl_external_bitflags_serde {
     };
 }
 
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 #[cfg(not(feature = "serde"))]
 macro_rules! __impl_external_bitflags_serde {
@@ -182,7 +182,7 @@ pub mod arbitrary;
 mod bytemuck;
 
 /// Implement `Arbitrary` for the internal bitflags type.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 #[cfg(feature = "arbitrary")]
 macro_rules! __impl_external_bitflags_arbitrary {
@@ -204,7 +204,7 @@ macro_rules! __impl_external_bitflags_arbitrary {
     };
 }
 
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 #[cfg(not(feature = "arbitrary"))]
 macro_rules! __impl_external_bitflags_arbitrary {
@@ -219,7 +219,7 @@ macro_rules! __impl_external_bitflags_arbitrary {
 }
 
 /// Implement `Pod` and `Zeroable` for the internal bitflags type.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 #[cfg(feature = "bytemuck")]
 macro_rules! __impl_external_bitflags_bytemuck {
@@ -247,7 +247,7 @@ macro_rules! __impl_external_bitflags_bytemuck {
     };
 }
 
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 #[cfg(not(feature = "bytemuck"))]
 macro_rules! __impl_external_bitflags_bytemuck {

--- a/src/external.rs
+++ b/src/external.rs
@@ -92,7 +92,7 @@ macro_rules! __impl_external_bitflags {
         // Use `serde` as an example: generate code when the feature is available,
         // and a no-op when it isn't
 
-        __impl_external_bitflags_serde! {
+        $crate::__impl_external_bitflags_serde! {
             $InternalBitFlags: $T, $PublicBitFlags {
                 $(
                     $(#[$inner $($args)*])*
@@ -101,7 +101,7 @@ macro_rules! __impl_external_bitflags {
             }
         }
 
-        __impl_external_bitflags_arbitrary! {
+        $crate::__impl_external_bitflags_arbitrary! {
             $InternalBitFlags: $T, $PublicBitFlags {
                 $(
                     $(#[$inner $($args)*])*
@@ -110,7 +110,7 @@ macro_rules! __impl_external_bitflags {
             }
         }
 
-        __impl_external_bitflags_bytemuck! {
+        $crate::__impl_external_bitflags_bytemuck! {
             $InternalBitFlags: $T, $PublicBitFlags {
                 $(
                     $(#[$inner $($args)*])*

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -6,7 +6,7 @@
 /// Declare the `bitflags`-facing bitflags struct.
 ///
 /// This type is part of the `bitflags` crate's public API, but not part of the user's.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 macro_rules! __declare_internal_bitflags {
     (
@@ -25,7 +25,7 @@ macro_rules! __declare_internal_bitflags {
 ///
 /// Methods and trait implementations can be freely added here without breaking end-users.
 /// If we want to expose new functionality to `#[derive]`, this is the place to do it.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 macro_rules! __impl_internal_bitflags {
     (

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -97,7 +97,7 @@ macro_rules! __impl_internal_bitflags {
 
         // The internal flags type offers a similar API to the public one
 
-        __impl_public_bitflags! {
+        $crate::__impl_public_bitflags! {
             $InternalBitFlags: $T, $PublicBitFlags {
                 $(
                     $(#[$inner $($args)*])*
@@ -106,11 +106,11 @@ macro_rules! __impl_internal_bitflags {
             }
         }
 
-        __impl_public_bitflags_ops! {
+        $crate::__impl_public_bitflags_ops! {
             $InternalBitFlags
         }
 
-        __impl_public_bitflags_iter! {
+        $crate::__impl_public_bitflags_iter! {
             $InternalBitFlags: $T, $PublicBitFlags
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -442,7 +442,7 @@ bitflags! {
 }
 ```
 */
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! bitflags {
     (
         $(#[$outer:meta])*
@@ -588,7 +588,7 @@ macro_rules! bitflags {
 ///
 /// We need to be careful about adding new methods and trait implementations here because they
 /// could conflict with items added by the end-user.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 macro_rules! __impl_bitflags {
     (
@@ -797,7 +797,7 @@ macro_rules! __impl_bitflags {
 ///
 /// If you find yourself with an attribute that should be considered expression-safe
 /// and isn't, it can be added here.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 macro_rules! __bitflags_expr_safe_attrs {
     // Entrypoint: Move all flags and all attributes into `unprocessed` lists
@@ -885,7 +885,7 @@ macro_rules! __bitflags_expr_safe_attrs {
 }
 
 /// Implement a flag, which may be a wildcard `_`.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 macro_rules! __bitflags_flag {
     (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -457,13 +457,13 @@ macro_rules! bitflags {
     ) => {
         // Declared in the scope of the `bitflags!` call
         // This type appears in the end-user's API
-        __declare_public_bitflags! {
+        $crate::__declare_public_bitflags! {
             $(#[$outer])*
             $vis struct $BitFlags
         }
 
         // Workaround for: https://github.com/bitflags/bitflags/issues/320
-        __impl_public_bitflags_consts! {
+        $crate::__impl_public_bitflags_consts! {
             $BitFlags: $T {
                 $(
                     $(#[$inner $($args)*])*
@@ -488,11 +488,11 @@ macro_rules! bitflags {
         const _: () = {
             // Declared in a "hidden" scope that can't be reached directly
             // These types don't appear in the end-user's API
-            __declare_internal_bitflags! {
+            $crate::__declare_internal_bitflags! {
                 $vis struct InternalBitFlags: $T
             }
 
-            __impl_internal_bitflags! {
+            $crate::__impl_internal_bitflags! {
                 InternalBitFlags: $T, $BitFlags {
                     $(
                         $(#[$inner $($args)*])*
@@ -502,7 +502,7 @@ macro_rules! bitflags {
             }
 
             // This is where new library trait implementations can be added
-            __impl_external_bitflags! {
+            $crate::__impl_external_bitflags! {
                 InternalBitFlags: $T, $BitFlags {
                     $(
                         $(#[$inner $($args)*])*
@@ -511,20 +511,20 @@ macro_rules! bitflags {
                 }
             }
 
-            __impl_public_bitflags_forward! {
+            $crate::__impl_public_bitflags_forward! {
                 $BitFlags: $T, InternalBitFlags
             }
 
-            __impl_public_bitflags_ops! {
+            $crate::__impl_public_bitflags_ops! {
                 $BitFlags
             }
 
-            __impl_public_bitflags_iter! {
+            $crate::__impl_public_bitflags_iter! {
                 $BitFlags: $T, $BitFlags
             }
         };
 
-        bitflags! {
+        $crate::bitflags! {
             $($t)*
         }
     };
@@ -538,7 +538,7 @@ macro_rules! bitflags {
 
         $($t:tt)*
     ) => {
-        __impl_public_bitflags_consts! {
+        $crate::__impl_public_bitflags_consts! {
             $BitFlags: $T {
                 $(
                     $(#[$inner $($args)*])*
@@ -559,7 +559,7 @@ macro_rules! bitflags {
             clippy::iter_without_into_iter,
         )]
         const _: () = {
-            __impl_public_bitflags! {
+            $crate::__impl_public_bitflags! {
                 $BitFlags: $T, $BitFlags {
                     $(
                         $(#[$inner $($args)*])*
@@ -568,16 +568,16 @@ macro_rules! bitflags {
                 }
             }
 
-            __impl_public_bitflags_ops! {
+            $crate::__impl_public_bitflags_ops! {
                 $BitFlags
             }
 
-            __impl_public_bitflags_iter! {
+            $crate::__impl_public_bitflags_iter! {
                 $BitFlags: $T, $BitFlags
             }
         };
 
-        bitflags! {
+        $crate::bitflags! {
             $($t)*
         }
     };
@@ -806,7 +806,7 @@ macro_rules! __bitflags_expr_safe_attrs {
         $(#[$inner:ident $($args:tt)*])*
         { $e:expr }
     ) => {
-        __bitflags_expr_safe_attrs! {
+        $crate::__bitflags_expr_safe_attrs! {
             expr: { $e },
             attrs: {
                 // All attributes start here
@@ -831,7 +831,7 @@ macro_rules! __bitflags_expr_safe_attrs {
             processed: [$($expr:tt)*],
         },
     ) => {
-        __bitflags_expr_safe_attrs! {
+        $crate::__bitflags_expr_safe_attrs! {
             expr: { $e },
             attrs: {
                 unprocessed: [
@@ -858,7 +858,7 @@ macro_rules! __bitflags_expr_safe_attrs {
             processed: [$($expr:tt)*],
         },
     ) => {
-        __bitflags_expr_safe_attrs! {
+        $crate::__bitflags_expr_safe_attrs! {
             expr: { $e },
                 attrs: {
                 unprocessed: [

--- a/src/public.rs
+++ b/src/public.rs
@@ -6,7 +6,7 @@
 /// Declare the user-facing bitflags struct.
 ///
 /// This type is guaranteed to be a newtype with a `bitflags`-facing type as its single field.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 macro_rules! __declare_public_bitflags {
     (
@@ -22,7 +22,7 @@ macro_rules! __declare_public_bitflags {
 ///
 /// We need to be careful about adding new methods and trait implementations here because they
 /// could conflict with items added by the end-user.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 macro_rules! __impl_public_bitflags_forward {
     (
@@ -124,7 +124,7 @@ macro_rules! __impl_public_bitflags_forward {
 ///
 /// We need to be careful about adding new methods and trait implementations here because they
 /// could conflict with items added by the end-user.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 macro_rules! __impl_public_bitflags {
     (
@@ -268,7 +268,7 @@ macro_rules! __impl_public_bitflags {
 }
 
 /// Implement iterators on the public (user-facing) bitflags type.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 macro_rules! __impl_public_bitflags_iter {
     ($BitFlags:ident: $T:ty, $PublicBitFlags:ident) => {
@@ -312,7 +312,7 @@ macro_rules! __impl_public_bitflags_iter {
 }
 
 /// Implement traits on the public (user-facing) bitflags type.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 macro_rules! __impl_public_bitflags_ops {
     ($PublicBitFlags:ident) => {
@@ -472,7 +472,7 @@ macro_rules! __impl_public_bitflags_ops {
 }
 
 /// Implement constants on the public (user-facing) bitflags type.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 macro_rules! __impl_public_bitflags_consts {
     (

--- a/src/public.rs
+++ b/src/public.rs
@@ -28,7 +28,7 @@ macro_rules! __impl_public_bitflags_forward {
     (
         $PublicBitFlags:ident: $T:ty, $InternalBitFlags:ident
     ) => {
-        __impl_bitflags! {
+        $crate::__impl_bitflags! {
             $PublicBitFlags: $T {
                 fn empty() {
                     Self($InternalBitFlags::empty())
@@ -135,7 +135,7 @@ macro_rules! __impl_public_bitflags {
             )*
         }
     ) => {
-        __impl_bitflags! {
+        $crate::__impl_bitflags! {
             $BitFlags: $T {
                 fn empty() {
                     Self(<$T as $crate::Bits>::EMPTY)
@@ -146,7 +146,7 @@ macro_rules! __impl_public_bitflags {
                     let mut i = 0;
 
                     $(
-                        __bitflags_expr_safe_attrs!(
+                        $crate::__bitflags_expr_safe_attrs!(
                             $(#[$inner $($args)*])*
                             {{
                                 let flag = <$PublicBitFlags as $crate::Flags>::FLAGS[i].value().bits();
@@ -185,10 +185,10 @@ macro_rules! __impl_public_bitflags {
 
                 fn from_name(name) {
                     $(
-                        __bitflags_flag!({
+                        $crate::__bitflags_flag!({
                             name: $Flag,
                             named: {
-                                __bitflags_expr_safe_attrs!(
+                                $crate::__bitflags_expr_safe_attrs!(
                                     $(#[$inner $($args)*])*
                                     {
                                         if name == $crate::__private::core::stringify!($Flag) {
@@ -485,7 +485,7 @@ macro_rules! __impl_public_bitflags_consts {
     ) => {
         impl $PublicBitFlags {
             $(
-                __bitflags_flag!({
+                $crate::__bitflags_flag!({
                     name: $Flag,
                     named: {
                         $(#[$inner $($args)*])*
@@ -503,10 +503,10 @@ macro_rules! __impl_public_bitflags_consts {
         impl $crate::Flags for $PublicBitFlags {
             const FLAGS: &'static [$crate::Flag<$PublicBitFlags>] = &[
                 $(
-                    __bitflags_flag!({
+                    $crate::__bitflags_flag!({
                         name: $Flag,
                         named: {
-                            __bitflags_expr_safe_attrs!(
+                            $crate::__bitflags_expr_safe_attrs!(
                                 $(#[$inner $($args)*])*
                                 {
                                     #[allow(
@@ -518,7 +518,7 @@ macro_rules! __impl_public_bitflags_consts {
                             )
                         },
                         unnamed: {
-                            __bitflags_expr_safe_attrs!(
+                            $crate::__bitflags_expr_safe_attrs!(
                                 $(#[$inner $($args)*])*
                                 {
                                     #[allow(

--- a/tests/compile-fail/access_outside_visibility.stderr
+++ b/tests/compile-fail/access_outside_visibility.stderr
@@ -15,4 +15,4 @@ note: the struct `Flags2` is defined here
 11 | |         }
 12 | |     }
    | |_____^
-   = note: this error originates in the macro `__declare_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__declare_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail/bitflags_redefined.stderr
+++ b/tests/compile-fail/bitflags_redefined.stderr
@@ -16,7 +16,7 @@ error[E0428]: the name `Flags1` is defined multiple times
    | |_- previous definition of the type `Flags1` here
    |
    = note: `Flags1` must be defined only once in the type namespace of this module
-   = note: this error originates in the macro `__declare_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__declare_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0601]: `main` function not found in crate `$CRATE`
   --> tests/compile-fail/bitflags_redefined.rs:14:2
@@ -41,7 +41,7 @@ error[E0119]: conflicting implementations of trait `Flags` for type `Flags1`
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_consts` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_consts` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `PublicFlags` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
@@ -60,7 +60,7 @@ error[E0119]: conflicting implementations of trait `PublicFlags` for type `Flags
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
-   = note: this error originates in the macro `__impl_internal_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_internal_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `Binary` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
@@ -79,7 +79,7 @@ error[E0119]: conflicting implementations of trait `Binary` for type `Flags1`
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `Octal` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
@@ -98,7 +98,7 @@ error[E0119]: conflicting implementations of trait `Octal` for type `Flags1`
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `LowerHex` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
@@ -117,7 +117,7 @@ error[E0119]: conflicting implementations of trait `LowerHex` for type `Flags1`
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `UpperHex` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
@@ -136,7 +136,7 @@ error[E0119]: conflicting implementations of trait `UpperHex` for type `Flags1`
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `BitOr` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
@@ -155,7 +155,7 @@ error[E0119]: conflicting implementations of trait `BitOr` for type `Flags1`
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `BitOrAssign` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
@@ -174,7 +174,7 @@ error[E0119]: conflicting implementations of trait `BitOrAssign` for type `Flags
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `BitXor` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
@@ -193,7 +193,7 @@ error[E0119]: conflicting implementations of trait `BitXor` for type `Flags1`
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `BitXorAssign` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
@@ -212,7 +212,7 @@ error[E0119]: conflicting implementations of trait `BitXorAssign` for type `Flag
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `BitAnd` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
@@ -231,7 +231,7 @@ error[E0119]: conflicting implementations of trait `BitAnd` for type `Flags1`
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `BitAndAssign` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
@@ -250,7 +250,7 @@ error[E0119]: conflicting implementations of trait `BitAndAssign` for type `Flag
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `Sub` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
@@ -269,7 +269,7 @@ error[E0119]: conflicting implementations of trait `Sub` for type `Flags1`
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `SubAssign` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
@@ -288,7 +288,7 @@ error[E0119]: conflicting implementations of trait `SubAssign` for type `Flags1`
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `Not` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
@@ -307,7 +307,7 @@ error[E0119]: conflicting implementations of trait `Not` for type `Flags1`
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `Extend<Flags1>` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
@@ -326,7 +326,7 @@ error[E0119]: conflicting implementations of trait `Extend<Flags1>` for type `Fl
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `FromIterator<Flags1>` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
@@ -345,7 +345,7 @@ error[E0119]: conflicting implementations of trait `FromIterator<Flags1>` for ty
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `IntoIterator` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
@@ -364,7 +364,7 @@ error[E0119]: conflicting implementations of trait `IntoIterator` for type `Flag
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `A`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -383,7 +383,7 @@ error[E0592]: duplicate definitions with name `A`
 14 | | }
    | |_- other definition for `A`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_consts` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_consts` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `empty`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -402,7 +402,7 @@ error[E0592]: duplicate definitions with name `empty`
 14 | | }
    | |_- other definition for `empty`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `all`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -421,7 +421,7 @@ error[E0592]: duplicate definitions with name `all`
 14 | | }
    | |_- other definition for `all`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `bits`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -440,7 +440,7 @@ error[E0592]: duplicate definitions with name `bits`
 14 | | }
    | |_- other definition for `bits`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `from_bits`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -459,7 +459,7 @@ error[E0592]: duplicate definitions with name `from_bits`
 14 | | }
    | |_- other definition for `from_bits`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `from_bits_truncate`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -478,7 +478,7 @@ error[E0592]: duplicate definitions with name `from_bits_truncate`
 14 | | }
    | |_- other definition for `from_bits_truncate`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `from_bits_retain`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -497,7 +497,7 @@ error[E0592]: duplicate definitions with name `from_bits_retain`
 14 | | }
    | |_- other definition for `from_bits_retain`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `from_name`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -516,7 +516,7 @@ error[E0592]: duplicate definitions with name `from_name`
 14 | | }
    | |_- other definition for `from_name`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `is_empty`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -535,7 +535,7 @@ error[E0592]: duplicate definitions with name `is_empty`
 14 | | }
    | |_- other definition for `is_empty`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `is_all`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -554,7 +554,7 @@ error[E0592]: duplicate definitions with name `is_all`
 14 | | }
    | |_- other definition for `is_all`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `intersects`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -573,7 +573,7 @@ error[E0592]: duplicate definitions with name `intersects`
 14 | | }
    | |_- other definition for `intersects`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `contains`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -592,7 +592,7 @@ error[E0592]: duplicate definitions with name `contains`
 14 | | }
    | |_- other definition for `contains`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `insert`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -611,7 +611,7 @@ error[E0592]: duplicate definitions with name `insert`
 14 | | }
    | |_- other definition for `insert`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `remove`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -630,7 +630,7 @@ error[E0592]: duplicate definitions with name `remove`
 14 | | }
    | |_- other definition for `remove`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `toggle`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -649,7 +649,7 @@ error[E0592]: duplicate definitions with name `toggle`
 14 | | }
    | |_- other definition for `toggle`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `set`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -668,7 +668,7 @@ error[E0592]: duplicate definitions with name `set`
 14 | | }
    | |_- other definition for `set`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `intersection`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -687,7 +687,7 @@ error[E0592]: duplicate definitions with name `intersection`
 14 | | }
    | |_- other definition for `intersection`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `union`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -706,7 +706,7 @@ error[E0592]: duplicate definitions with name `union`
 14 | | }
    | |_- other definition for `union`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `difference`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -725,7 +725,7 @@ error[E0592]: duplicate definitions with name `difference`
 14 | | }
    | |_- other definition for `difference`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `symmetric_difference`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -744,7 +744,7 @@ error[E0592]: duplicate definitions with name `symmetric_difference`
 14 | | }
    | |_- other definition for `symmetric_difference`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `complement`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -763,7 +763,7 @@ error[E0592]: duplicate definitions with name `complement`
 14 | | }
    | |_- other definition for `complement`
    |
-   = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `iter`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -782,7 +782,7 @@ error[E0592]: duplicate definitions with name `iter`
 14 | | }
    | |_- other definition for `iter`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `iter_names`
   --> tests/compile-fail/bitflags_redefined.rs:4:1
@@ -801,4 +801,4 @@ error[E0592]: duplicate definitions with name `iter_names`
 14 | | }
    | |_- other definition for `iter_names`
    |
-   = note: this error originates in the macro `__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail/unnamed_const.stderr
+++ b/tests/compile-fail/unnamed_const.stderr
@@ -36,4 +36,4 @@ note: if you're trying to build a new `Unnamed` consider using one of the follow
 8 | |     }
 9 | | }
   | |_^
-  = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
`macro_export(local_inner_macros)` is an outdated workaround that is only relevant for supporting compilers from Rust 1.29 and older.

Currently bitflags's oldest supported compiler is Rust 1.56, so there should be no reason to use `local_inner_macros`.