### PR TITLE
Remove old `unused_tuple_struct_fields` lint

### DIFF
--- a/tests/smoke-test/src/main.rs
+++ b/tests/smoke-test/src/main.rs
@@ -35,7 +35,6 @@
     unused_lifetimes,
     unused_qualifications,
     unused_results,
-    unused_tuple_struct_fields,
     variant_size_differences
 )]
 


### PR DESCRIPTION
`unused_tuple_struct_fields` no longer exists in Rust 1.77 since https://github.com/rust-lang/rust/pull/118297. It has been subsumed by `dead_code`.

This is causing the "smoke test" in CI to fail.

https://github.com/bitflags/bitflags/blob/586d81916cc961c4f2c0517620dd323f38e853d4/.github/workflows/rust.yml#L38-L39

```console
$ cargo run --manifest-path tests/smoke-test/Cargo.toml

error: lint `unused_tuple_struct_fields` has been renamed to `dead_code`
  --> src/main.rs:38:5
   |
38 |     unused_tuple_struct_fields,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `dead_code`
   |
note: the lint level is defined here
  --> src/main.rs:6:5
   |
6  |     warnings,
   |     ^^^^^^^^
   = note: `#[deny(renamed_and_removed_lints)]` implied by `#[deny(warnings)]`
```