### PR TITLE
Derive `Debug` for `Flag<B>`

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -11,6 +11,7 @@ use crate::{
 /**
 A defined flags value that may be named or unnamed.
 */
+#[derive(Debug)]
 pub struct Flag<B> {
     name: &'static str,
     value: B,


### PR DESCRIPTION
This just makes it possible to easily print the `FLAGS` constant.