### PR TITLE
Prepare for 2.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2.5.0
+
+## What's Changed
+* Derive `Debug` for `Flag<B>` by @tgross35 in https://github.com/bitflags/bitflags/pull/398
+* Support truncating or strict-named variants of parsing and formatting by @KodrAus in https://github.com/bitflags/bitflags/pull/400
+
+## New Contributors
+* @tgross35 made their first contribution in https://github.com/bitflags/bitflags/pull/398
+
+**Full Changelog**: https://github.com/bitflags/bitflags/compare/2.4.2...2.5.0
+
 # 2.4.2
 
 ## What's Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitflags"
 # NB: When modifying, also modify the number in readme (for breaking changes)
-version = "2.4.2"
+version = "2.5.0"
 edition = "2021"
 rust-version = "1.56.0"
 authors = ["The Rust Project Developers"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bitflags = "2.4.2"
+bitflags = "2.5.0"
 ```
 
 and this to your source code:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ Add `bitflags` to your `Cargo.toml`:
 
 ```toml
 [dependencies.bitflags]
-version = "2.4.2"
+version = "2.5.0"
 ```
 
 ## Generating flags types


### PR DESCRIPTION
## What's Changed
* Derive `Debug` for `Flag<B>` by @tgross35 in https://github.com/bitflags/bitflags/pull/398
* Support truncating or strict-named variants of parsing and formatting by @KodrAus in https://github.com/bitflags/bitflags/pull/400

## New Contributors
* @tgross35 made their first contribution in https://github.com/bitflags/bitflags/pull/398