### PR TITLE
Update error messages and zerocopy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rustversion = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 serde_test = "1.0"
-zerocopy = "0.6"
+zerocopy = { version = "0.7", features = ["derive"] }
 arbitrary = { version = "1.0", features = ["derive"] }
 bytemuck = { version = "1.0", features = ["derive"] }
 

--- a/examples/custom_derive.rs
+++ b/examples/custom_derive.rs
@@ -6,7 +6,7 @@ use bitflags::bitflags;
 
 // Define a flags type outside of the `bitflags` macro as a newtype
 // It can accept custom derives for libaries `bitflags` doesn't support natively
-#[derive(zerocopy::AsBytes, zerocopy::FromBytes)]
+#[derive(zerocopy::AsBytes, zerocopy::FromBytes, zerocopy::FromZeroes)]
 #[repr(transparent)]
 pub struct ManualFlags(u32);
 

--- a/tests/compile-fail/bitflags_custom_bits.rs
+++ b/tests/compile-fail/bitflags_custom_bits.rs
@@ -124,7 +124,7 @@ impl ParseHex for MyInt {
 }
 
 impl WriteHex for MyInt {
-    fn write_hex<W: fmt::Write>(&self, writer: W) -> fmt::Result {
+    fn write_hex<W: fmt::Write>(&self, mut writer: W) -> fmt::Result {
         write!(writer, "{:x}", self.0)
     }
 }

--- a/tests/compile-fail/bitflags_custom_bits.stderr
+++ b/tests/compile-fail/bitflags_custom_bits.stderr
@@ -19,3 +19,323 @@ note: required by a bound in `PublicFlags::Primitive`
     |
     |     type Primitive: Primitive;
     |                     ^^^^^^^^^ required by this bound in `PublicFlags::Primitive`
+
+error[E0015]: cannot call non-const operator in constant functions
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
+    |
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
+    | |_^
+    |
+note: impl defined here, but it is not `const`
+   --> tests/compile-fail/bitflags_custom_bits.rs:42:1
+    |
+42  | impl BitOr for MyInt {
+    | ^^^^^^^^^^^^^^^^^^^^
+    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0015]: cannot call non-const operator in constant functions
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
+    |
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
+    | |_^
+    |
+note: impl defined here, but it is not `const`
+   --> tests/compile-fail/bitflags_custom_bits.rs:26:23
+    |
+26  | #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    |                       ^^^^^^^^^
+    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0015]: cannot call non-const operator in constant functions
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
+    |
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
+    | |_^
+    |
+note: impl defined here, but it is not `const`
+   --> tests/compile-fail/bitflags_custom_bits.rs:34:1
+    |
+34  | impl BitAnd for MyInt {
+    | ^^^^^^^^^^^^^^^^^^^^^
+    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0015]: cannot call non-const operator in constant functions
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
+    |
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
+    | |_^
+    |
+note: impl defined here, but it is not `const`
+   --> tests/compile-fail/bitflags_custom_bits.rs:26:23
+    |
+26  | #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    |                       ^^^^^^^^^
+    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0015]: cannot call non-const operator in constant functions
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
+    |
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
+    | |_^
+    |
+note: impl defined here, but it is not `const`
+   --> tests/compile-fail/bitflags_custom_bits.rs:42:1
+    |
+42  | impl BitOr for MyInt {
+    | ^^^^^^^^^^^^^^^^^^^^
+    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0015]: cannot call non-const operator in constant functions
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
+    |
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
+    | |_^
+    |
+note: impl defined here, but it is not `const`
+   --> tests/compile-fail/bitflags_custom_bits.rs:26:23
+    |
+26  | #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    |                       ^^^^^^^^^
+    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0015]: cannot call non-const operator in constant functions
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
+    |
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
+    | |_^
+    |
+note: impl defined here, but it is not `const`
+   --> tests/compile-fail/bitflags_custom_bits.rs:34:1
+    |
+34  | impl BitAnd for MyInt {
+    | ^^^^^^^^^^^^^^^^^^^^^
+    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0015]: cannot call non-const operator in constant functions
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
+    |
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
+    | |_^
+    |
+note: impl defined here, but it is not `const`
+   --> tests/compile-fail/bitflags_custom_bits.rs:26:23
+    |
+26  | #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    |                       ^^^^^^^^^
+    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0015]: cannot call non-const operator in constant functions
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
+    |
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
+    | |_^
+    |
+note: impl defined here, but it is not `const`
+   --> tests/compile-fail/bitflags_custom_bits.rs:34:1
+    |
+34  | impl BitAnd for MyInt {
+    | ^^^^^^^^^^^^^^^^^^^^^
+    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0015]: cannot call non-const operator in constant functions
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
+    |
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
+    | |_^
+    |
+note: impl defined here, but it is not `const`
+   --> tests/compile-fail/bitflags_custom_bits.rs:26:23
+    |
+26  | #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    |                       ^^^^^^^^^
+    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0015]: cannot call non-const operator in constant functions
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
+    |
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
+    | |_^
+    |
+note: impl defined here, but it is not `const`
+   --> tests/compile-fail/bitflags_custom_bits.rs:34:1
+    |
+34  | impl BitAnd for MyInt {
+    | ^^^^^^^^^^^^^^^^^^^^^
+    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0015]: cannot call non-const operator in constant functions
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
+    |
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
+    | |_^
+    |
+note: impl defined here, but it is not `const`
+   --> tests/compile-fail/bitflags_custom_bits.rs:42:1
+    |
+42  | impl BitOr for MyInt {
+    | ^^^^^^^^^^^^^^^^^^^^
+    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0015]: cannot call non-const operator in constant functions
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
+    |
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
+    | |_^
+    |
+note: impl defined here, but it is not `const`
+   --> tests/compile-fail/bitflags_custom_bits.rs:76:1
+    |
+76  | impl Not for MyInt {
+    | ^^^^^^^^^^^^^^^^^^
+    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0015]: cannot call non-const operator in constant functions
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
+    |
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
+    | |_^
+    |
+note: impl defined here, but it is not `const`
+   --> tests/compile-fail/bitflags_custom_bits.rs:34:1
+    |
+34  | impl BitAnd for MyInt {
+    | ^^^^^^^^^^^^^^^^^^^^^
+    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0015]: cannot call non-const operator in constant functions
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
+    |
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
+    | |_^
+    |
+note: impl defined here, but it is not `const`
+   --> tests/compile-fail/bitflags_custom_bits.rs:50:1
+    |
+50  | impl BitXor for MyInt {
+    | ^^^^^^^^^^^^^^^^^^^^^
+    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0015]: cannot call non-const operator in constant functions
+   --> tests/compile-fail/bitflags_custom_bits.rs:132:1
+    |
+132 | / bitflags! {
+133 | |     struct Flags128: MyInt {
+134 | |         const A = MyInt(0b0000_0001u8);
+135 | |         const B = MyInt(0b0000_0010u8);
+136 | |         const C = MyInt(0b0000_0100u8);
+137 | |     }
+138 | | }
+    | |_^
+    |
+note: impl defined here, but it is not `const`
+   --> tests/compile-fail/bitflags_custom_bits.rs:76:1
+    |
+76  | impl Not for MyInt {
+    | ^^^^^^^^^^^^^^^^^^
+    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail/bitflags_redefined.stderr
+++ b/tests/compile-fail/bitflags_redefined.stderr
@@ -24,25 +24,6 @@ error[E0601]: `main` function not found in crate `$CRATE`
 14 | }
    |  ^ consider adding a `main` function to `$DIR/tests/compile-fail/bitflags_redefined.rs`
 
-error[E0119]: conflicting implementations of trait `Flags` for type `Flags1`
-  --> tests/compile-fail/bitflags_redefined.rs:10:1
-   |
-4  | / bitflags! {
-5  | |     pub struct Flags1: u32 {
-6  | |         const A = 1;
-7  | |     }
-8  | | }
-   | |_- first implementation here
-9  |
-10 | / bitflags! {
-11 | |     pub struct Flags1: u32 {
-12 | |         const A = 1;
-13 | |     }
-14 | | }
-   | |_^ conflicting implementation for `Flags1`
-   |
-   = note: this error originates in the macro `$crate::__impl_public_bitflags_consts` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0119]: conflicting implementations of trait `PublicFlags` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
    |
@@ -61,6 +42,25 @@ error[E0119]: conflicting implementations of trait `PublicFlags` for type `Flags
    | |_^ conflicting implementation for `Flags1`
    |
    = note: this error originates in the macro `$crate::__impl_internal_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0119]: conflicting implementations of trait `Flags` for type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_- first implementation here
+9  |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ conflicting implementation for `Flags1`
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_consts` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `Binary` for type `Flags1`
   --> tests/compile-fail/bitflags_redefined.rs:10:1
@@ -364,6 +364,56 @@ error[E0119]: conflicting implementations of trait `IntoIterator` for type `Flag
 14 | | }
    | |_^ conflicting implementation for `Flags1`
    |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+note: the requirement `_ <: _` appears on the `impl`'s method `into_iter` but not on the corresponding trait's method
+ --> $RUST/core/src/iter/traits/collect.rs
+  |
+  = note: in this trait
+ ::: $RUST/core/src/iter/traits/collect.rs
+  |
+  = note: this trait's method doesn't have the requirement `_ <: _`
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__declare_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+note: the requirement `_ <: _` appears on the `impl`'s method `into_iter` but not on the corresponding trait's method
+  --> $RUST/core/src/iter/traits/collect.rs
+   |
+   = note: in this trait
+  ::: $RUST/core/src/iter/traits/collect.rs
+   |
+   = note: this trait's method doesn't have the requirement `_ <: _`
    = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `A`
@@ -800,5 +850,2569 @@ error[E0592]: duplicate definitions with name `iter_names`
 13 | |     }
 14 | | }
    | |_- other definition for `iter_names`
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_consts` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:6:15
+   |
+6  |         const A = 1;
+   |               ^ multiple `A` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_consts` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `bits` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_consts` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_consts` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0283]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: cannot satisfy `_: WriteHex`
+  = help: the following types implement trait `WriteHex`:
+            isize
+            i8
+            i16
+            i32
+            i64
+            i128
+            usize
+            u8
+          and $N others
+note: required by a bound in `to_writer`
+ --> src/parser.rs
+  |
+  | pub fn to_writer<B: Flags>(flags: &B, mut writer: impl Write) -> Result<(), fmt::Error>
+  |        --------- required by a bound in this function
+  | where
+  |     B::Bits: WriteHex,
+  |              ^^^^^^^^ required by this bound in `to_writer`
+  = note: this error originates in the macro `$crate::__impl_internal_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0283]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: cannot satisfy `_: ParseHex`
+  = help: the following types implement trait `ParseHex`:
+            isize
+            i8
+            i16
+            i32
+            i64
+            i128
+            usize
+            u8
+          and $N others
+note: required by a bound in `bitflags::parser::from_str`
+ --> src/parser.rs
+  |
+  | pub fn from_str<B: Flags>(input: &str) -> Result<B, ParseError>
+  |        -------- required by a bound in this function
+  | where
+  |     B::Bits: ParseHex,
+  |              ^^^^^^^^ required by this bound in `from_str`
+  = note: this error originates in the macro `$crate::__impl_internal_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `bits` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `union` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `insert` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `symmetric_difference` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `toggle` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `intersection` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `bits` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `difference` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `remove` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `complement` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `insert` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `empty` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `bits` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `bits` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `bits` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `bits` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^ multiple `iter` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_consts` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:12:15
+   |
+12 |         const A = 1;
+   |               ^ multiple `A` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_consts` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `bits` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_consts` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_consts` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0283]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: cannot satisfy `_: WriteHex`
+   = help: the following types implement trait `WriteHex`:
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+             usize
+             u8
+           and $N others
+note: required by a bound in `to_writer`
+  --> src/parser.rs
+   |
+   | pub fn to_writer<B: Flags>(flags: &B, mut writer: impl Write) -> Result<(), fmt::Error>
+   |        --------- required by a bound in this function
+   | where
+   |     B::Bits: WriteHex,
+   |              ^^^^^^^^ required by this bound in `to_writer`
+   = note: this error originates in the macro `$crate::__impl_internal_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0283]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: cannot satisfy `_: ParseHex`
+   = help: the following types implement trait `ParseHex`:
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+             usize
+             u8
+           and $N others
+note: required by a bound in `bitflags::parser::from_str`
+  --> src/parser.rs
+   |
+   | pub fn from_str<B: Flags>(input: &str) -> Result<B, ParseError>
+   |        -------- required by a bound in this function
+   | where
+   |     B::Bits: ParseHex,
+   |              ^^^^^^^^ required by this bound in `from_str`
+   = note: this error originates in the macro `$crate::__impl_internal_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `bits` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_forward` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `union` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `insert` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `symmetric_difference` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `toggle` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `intersection` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `bits` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `difference` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `remove` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `complement` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `insert` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `empty` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_ops` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `bits` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `bits` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `bits` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `from_bits_retain` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `bits` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ multiple `iter` found
+   |
+note: candidate #1 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+4  | / bitflags! {
+5  | |     pub struct Flags1: u32 {
+6  | |         const A = 1;
+7  | |     }
+8  | | }
+   | |_^
+note: candidate #2 is defined in an impl for the type `Flags1`
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/compile-fail/bitflags_redefined.rs:4:1
+  |
+4 | / bitflags! {
+5 | |     pub struct Flags1: u32 {
+6 | |         const A = 1;
+7 | |     }
+8 | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/compile-fail/bitflags_redefined.rs:10:1
+   |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_^ cannot infer type
    |
    = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail/unnamed_const.stderr
+++ b/tests/compile-fail/unnamed_const.stderr
@@ -12,10 +12,7 @@ error[E0599]: no associated item named `_` found for struct `Unnamed` in the cur
 5 | |         const _ = 1;
 6 | |
 7 | |         const A = Self::_.bits();
-  | |                         ^
-  | |                         |
-  | |                         associated item not found in `Unnamed`
-  | |                         help: there is an associated constant with a similar name: `A`
+  | |                         ^ associated item not found in `Unnamed`
 8 | |     }
 9 | | }
   | |_- associated item `_` not found for this struct
@@ -37,3 +34,7 @@ note: if you're trying to build a new `Unnamed` consider using one of the follow
 9 | | }
   | |_^
   = note: this error originates in the macro `$crate::__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: there is an associated constant `A` with a similar name
+  |
+7 |         const A = Self::A.bits();
+  |                         ~


### PR DESCRIPTION
This PR just updates our error messages for the latest `beta`. It looks like the error messages for redefined flags types has become very noisy.

I've also updated our example using `zerocopy` to the latest version.