### PR TITLE
Bump minimum declared versions of dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,6 +38,20 @@ jobs:
     - name: Smoke test
       run: cargo run --manifest-path tests/smoke-test/Cargo.toml
 
+  check-minimal:
+    name: Check minimal versions
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+    - name: Install Rust Toolchain
+      run: rustup default nightly
+
+    - name: Check minimal versions
+      run: cargo check --all --features serde,arbitrary,bytemuck,std,example_generated --all-targets -Z minimal-versions
+
   benches:
     name: Benches
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,18 +18,18 @@ A macro to generate structures which behave like bitflags.
 exclude = ["/tests", "/.github"]
 
 [dependencies]
-serde = { version = "1.0", optional = true, default-features = false }
+serde = { version = "1.0.103", optional = true, default-features = false }
 arbitrary = { version = "1.0", optional = true }
-bytemuck = { version = "1.0", optional = true }
+bytemuck = { version = "1.12", optional = true }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 compiler_builtins = { version = "0.1.2", optional = true }
 
 [dev-dependencies]
-trybuild = "1.0"
+trybuild = "1.0.18"
 rustversion = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-serde_test = "1.0"
+serde_test = "1.0.19"
 zerocopy = { version = "0.7", features = ["derive"] }
 arbitrary = { version = "1.0", features = ["derive"] }
 bytemuck = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
When updating `bitflags` dependency of another crate, I found out that `bitflags`' declared dependency versions are lower than needed to actually build the crate.

This PR adds a GH workflow check inspired by the one from [`gbm.rs`](https://github.com/Smithay/gbm.rs/blob/754a9574bc879bb1256ab058ded0c4fa598dcbf6/.github/workflows/ci.yml#L95) that attempts a build with the minimal compatible versions of all dependencies.

Another commit in the PR bumps the declared versions to earliest ones I identified as working, to make the workflow pass.

The workflow builds all features other than `core` and `rustc-dep-of-std`. `cargo check --all --all-features --all-targets` failed for me on main with mentions of rustc/std, which successfully scared me away :laughing: I have zero experience hacking on rustc/std so I don't even know how those are used.

Hopefully this, or some parts of it can be useful as is :smile: 