### PR TITLE
chore(deps): bump serde_derive and bytemuck versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,12 @@ compiler_builtins = { version = "0.1.2", optional = true }
 [dev-dependencies]
 trybuild = "1.0.18"
 rustversion = "1.0"
-serde_derive = "1.0"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 serde_test = "1.0.19"
 zerocopy = { version = "0.7", features = ["derive"] }
 arbitrary = { version = "1.0", features = ["derive"] }
-bytemuck = { version = "1.0", features = ["derive"] }
+bytemuck = { version = "1.12.2", features = ["derive"] }
 
 [features]
 std = []


### PR DESCRIPTION
The version of the serde_derive and bytemuck crates specified is too low to satisfy the minimal versions checker.
This changes ensures that the correct minimal versions that allow the project to compile and run tests is chosen.
