### PR TITLE
Allow specifying outer attributes in impl mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ bitflags! {
 
 See the docs for the `bitflags` macro for the full syntax.
 
-Also see the [`example_generated`] module for an example of what the `bitflags` macro generates for a flags type.
+Also see the [`example_generated`](./example_generated/index.html) module for an example of what the `bitflags` macro generates for a flags type.
 
 ### Externally defined flags
 
@@ -530,6 +530,7 @@ macro_rules! bitflags {
         }
     };
     (
+        $(#[$outer:meta])*
         impl $BitFlags:ident: $T:ty {
             $(
                 $(#[$inner:ident $($args:tt)*])*
@@ -561,6 +562,7 @@ macro_rules! bitflags {
         )]
         const _: () = {
             $crate::__impl_public_bitflags! {
+                $(#[$outer])*
                 $BitFlags: $T, $BitFlags {
                     $(
                         $(#[$inner $($args)*])*
@@ -593,6 +595,7 @@ macro_rules! bitflags {
 #[doc(hidden)]
 macro_rules! __impl_bitflags {
     (
+        $(#[$outer:meta])*
         $PublicBitFlags:ident: $T:ty {
             fn empty() $empty:block
             fn all() $all:block
@@ -617,6 +620,7 @@ macro_rules! __impl_bitflags {
         }
     ) => {
         #[allow(dead_code, deprecated, unused_attributes)]
+        $(#[$outer])*
         impl $PublicBitFlags {
             /// Get a flags value with all bits unset.
             #[inline]

--- a/src/public.rs
+++ b/src/public.rs
@@ -26,9 +26,11 @@ macro_rules! __declare_public_bitflags {
 #[doc(hidden)]
 macro_rules! __impl_public_bitflags_forward {
     (
+        $(#[$outer:meta])*
         $PublicBitFlags:ident: $T:ty, $InternalBitFlags:ident
     ) => {
         $crate::__impl_bitflags! {
+            $(#[$outer])*
             $PublicBitFlags: $T {
                 fn empty() {
                     Self($InternalBitFlags::empty())
@@ -128,6 +130,7 @@ macro_rules! __impl_public_bitflags_forward {
 #[doc(hidden)]
 macro_rules! __impl_public_bitflags {
     (
+        $(#[$outer:meta])*
         $BitFlags:ident: $T:ty, $PublicBitFlags:ident {
             $(
                 $(#[$inner:ident $($args:tt)*])*
@@ -136,6 +139,7 @@ macro_rules! __impl_public_bitflags {
         }
     ) => {
         $crate::__impl_bitflags! {
+            $(#[$outer])*
             $BitFlags: $T {
                 fn empty() {
                     Self(<$T as $crate::Bits>::EMPTY)
@@ -271,7 +275,11 @@ macro_rules! __impl_public_bitflags {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __impl_public_bitflags_iter {
-    ($BitFlags:ident: $T:ty, $PublicBitFlags:ident) => {
+    (
+        $(#[$outer:meta])*
+        $BitFlags:ident: $T:ty, $PublicBitFlags:ident
+    ) => {
+        $(#[$outer])*
         impl $BitFlags {
             /// Yield a set of contained flags values.
             ///
@@ -300,6 +308,7 @@ macro_rules! __impl_public_bitflags_iter {
             }
         }
 
+        $(#[$outer:meta])*
         impl $crate::__private::core::iter::IntoIterator for $BitFlags {
             type Item = $PublicBitFlags;
             type IntoIter = $crate::iter::Iter<$PublicBitFlags>;
@@ -315,7 +324,12 @@ macro_rules! __impl_public_bitflags_iter {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __impl_public_bitflags_ops {
-    ($PublicBitFlags:ident) => {
+    (
+        $(#[$outer:meta])*
+        $PublicBitFlags:ident
+    ) => {
+
+        $(#[$outer])*
         impl $crate::__private::core::fmt::Binary for $PublicBitFlags {
             fn fmt(
                 &self,
@@ -326,6 +340,7 @@ macro_rules! __impl_public_bitflags_ops {
             }
         }
 
+        $(#[$outer])*
         impl $crate::__private::core::fmt::Octal for $PublicBitFlags {
             fn fmt(
                 &self,
@@ -336,6 +351,7 @@ macro_rules! __impl_public_bitflags_ops {
             }
         }
 
+        $(#[$outer])*
         impl $crate::__private::core::fmt::LowerHex for $PublicBitFlags {
             fn fmt(
                 &self,
@@ -346,6 +362,7 @@ macro_rules! __impl_public_bitflags_ops {
             }
         }
 
+        $(#[$outer])*
         impl $crate::__private::core::fmt::UpperHex for $PublicBitFlags {
             fn fmt(
                 &self,
@@ -356,6 +373,7 @@ macro_rules! __impl_public_bitflags_ops {
             }
         }
 
+        $(#[$outer])*
         impl $crate::__private::core::ops::BitOr for $PublicBitFlags {
             type Output = Self;
 
@@ -366,6 +384,7 @@ macro_rules! __impl_public_bitflags_ops {
             }
         }
 
+        $(#[$outer])*
         impl $crate::__private::core::ops::BitOrAssign for $PublicBitFlags {
             /// The bitwise or (`|`) of the bits in two flags values.
             #[inline]
@@ -374,6 +393,7 @@ macro_rules! __impl_public_bitflags_ops {
             }
         }
 
+        $(#[$outer])*
         impl $crate::__private::core::ops::BitXor for $PublicBitFlags {
             type Output = Self;
 
@@ -384,6 +404,7 @@ macro_rules! __impl_public_bitflags_ops {
             }
         }
 
+        $(#[$outer])*
         impl $crate::__private::core::ops::BitXorAssign for $PublicBitFlags {
             /// The bitwise exclusive-or (`^`) of the bits in two flags values.
             #[inline]
@@ -392,6 +413,7 @@ macro_rules! __impl_public_bitflags_ops {
             }
         }
 
+        $(#[$outer])*
         impl $crate::__private::core::ops::BitAnd for $PublicBitFlags {
             type Output = Self;
 
@@ -402,6 +424,7 @@ macro_rules! __impl_public_bitflags_ops {
             }
         }
 
+        $(#[$outer])*
         impl $crate::__private::core::ops::BitAndAssign for $PublicBitFlags {
             /// The bitwise and (`&`) of the bits in two flags values.
             #[inline]
@@ -410,6 +433,7 @@ macro_rules! __impl_public_bitflags_ops {
             }
         }
 
+        $(#[$outer])*
         impl $crate::__private::core::ops::Sub for $PublicBitFlags {
             type Output = Self;
 
@@ -423,6 +447,7 @@ macro_rules! __impl_public_bitflags_ops {
             }
         }
 
+        $(#[$outer])*
         impl $crate::__private::core::ops::SubAssign for $PublicBitFlags {
             /// The intersection of a source flags value with the complement of a target flags value (`&!`).
             ///
@@ -434,6 +459,7 @@ macro_rules! __impl_public_bitflags_ops {
             }
         }
 
+        $(#[$outer])*
         impl $crate::__private::core::ops::Not for $PublicBitFlags {
             type Output = Self;
 
@@ -444,6 +470,7 @@ macro_rules! __impl_public_bitflags_ops {
             }
         }
 
+        $(#[$outer])*
         impl $crate::__private::core::iter::Extend<$PublicBitFlags> for $PublicBitFlags {
             /// The bitwise or (`|`) of the bits in each flags value.
             fn extend<T: $crate::__private::core::iter::IntoIterator<Item = Self>>(
@@ -456,6 +483,7 @@ macro_rules! __impl_public_bitflags_ops {
             }
         }
 
+        $(#[$outer])*
         impl $crate::__private::core::iter::FromIterator<$PublicBitFlags> for $PublicBitFlags {
             /// The bitwise or (`|`) of the bits in each flags value.
             fn from_iter<T: $crate::__private::core::iter::IntoIterator<Item = Self>>(
@@ -476,6 +504,7 @@ macro_rules! __impl_public_bitflags_ops {
 #[doc(hidden)]
 macro_rules! __impl_public_bitflags_consts {
     (
+        $(#[$outer:meta])*
         $PublicBitFlags:ident: $T:ty {
             $(
                 $(#[$inner:ident $($args:tt)*])*
@@ -483,6 +512,7 @@ macro_rules! __impl_public_bitflags_consts {
             )*
         }
     ) => {
+        $(#[$outer])*
         impl $PublicBitFlags {
             $(
                 $crate::__bitflags_flag!({
@@ -500,6 +530,7 @@ macro_rules! __impl_public_bitflags_consts {
             )*
         }
 
+        $(#[$outer])*
         impl $crate::Flags for $PublicBitFlags {
             const FLAGS: &'static [$crate::Flag<$PublicBitFlags>] = &[
                 $(

--- a/tests/compile-pass/bitflags_impl_attrs.rs
+++ b/tests/compile-pass/bitflags_impl_attrs.rs
@@ -1,0 +1,13 @@
+extern crate bitflags;
+
+struct Example(u64);
+
+bitflags::bitflags! {
+    /// Docs on the `impl` block.
+    #[allow(dead_code)]
+    impl Example: u64 {
+        const flag = 0b01;
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Closes #406 

This PR lets you specify attributes in `bitflags! { impl .. }` invocations that apply to the `impl` block itself. For completeness, I've also added attribute support to all macros that expand to items, but haven't wired attributes from the top-level `bitflags!` macro up to them because that could break existing code that uses attributes that are only valid in certain contexts.