### PR TITLE
Use `serde_derive` via `derive` feature on `serde`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ compiler_builtins = { version = "0.1.2", optional = true }
 [dev-dependencies]
 trybuild = "1.0.18"
 rustversion = "1.0"
-serde_derive = "1.0.103"
+serde = { version = "1.0.103", features = ["derive"] }
 serde_json = "1.0"
 serde_test = "1.0.19"
 zerocopy = { version = "0.7", features = ["derive"] }

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -4,7 +4,7 @@
 
 #[cfg(feature = "serde")]
 fn main() {
-    use serde_derive::*;
+    use serde::{Deserialize, Serialize};
 
     bitflags::bitflags! {
         #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/src/external/serde.rs
+++ b/src/external/serde.rs
@@ -70,7 +70,7 @@ where
 mod tests {
     use serde_test::{assert_tokens, Configure, Token::*};
     bitflags! {
-        #[derive(serde_derive::Serialize, serde_derive::Deserialize, Debug, PartialEq, Eq)]
+        #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
         #[serde(transparent)]
         struct SerdeFlags: u32 {
             const A = 1;


### PR DESCRIPTION
This is the recommended way to do this in the `serde` docs.