### PR TITLE
feat(core): Add match_bitflag macro for bitflag matching

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -587,6 +587,90 @@ macro_rules! bitflags {
     () => {};
 }
 
+/// Match bitflag patterns similar to Rust's match expression
+///
+/// This macro allows for matching bitflag combinations in a way that resembles
+/// Rust's native match expression, but works correctly with bitflag operations.
+///
+/// # Requirements
+///
+/// - The struct used with this macro must implement `PartialEq`.
+/// - It's recommended to use this macro with structs created by the `bitflags!` macro.
+///
+/// # Syntax
+///
+/// ```ignore
+/// match_bitflag!(expression, {
+///     pattern1 => result1,
+///     pattern2 => result2,
+///     ...
+///     _ => default_result
+/// })
+/// ```
+///
+/// # Examples
+///
+/// ```rust
+/// use bitflags::{match_bitflag, bitflags};
+///
+/// bitflags! {
+///     #[derive(PartialEq)]
+///     struct Flags: u8 {
+///         const A = 1 << 0;
+///         const B = 1 << 1;
+///         const C = 1 << 2;
+///     }
+/// }
+///
+/// let flags = Flags::A | Flags::B;
+///
+/// match_bitflag!(expected, {
+///     Flags::A => println!("A"),
+///     Flags::B => println!("B"),
+///     Flags::C  => println!("C"),
+///     Flags::A | Flags::B =>{
+///          // println!("A | B");
+///          print!("A");
+///          print!(" | ");
+///          print!("B");
+///     },
+///     Flags::A | Flags::C => println!("A | C"),
+///     Flags::B | Flags::C => println!("B | C"),
+///     Flags::A | Flags::B | Flags::C => println!("A | B | C"),
+///     _ => println!("other")
+/// })
+/// ```
+///
+/// # How it works
+///
+/// The macro expands to a series of if-else statements, checking equality
+/// between the input expression and each pattern. This allows for correct
+/// matching of bitflag combinations, which is not possible with a regular
+/// match expression due to the way bitflags are implemented.
+///
+/// # Note
+///
+/// The order of patterns matters. The first matching pattern will be executed,
+/// so more specific patterns should come before more general ones.
+#[macro_export]
+macro_rules! match_bitflag {
+    ($operation:expr, {
+    $( $pattern:expr => $result:expr, )*
+        _ => $default:expr
+    }) => {
+        {
+            $(
+                if $operation == $pattern {
+                    $result
+                } else
+            )*
+            {
+                $default
+            }
+        }
+    };
+}
+
 /// Implement functions on bitflags types.
 ///
 /// We need to be careful about adding new methods and trait implementations here because they

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -18,6 +18,7 @@ mod intersects;
 mod is_all;
 mod is_empty;
 mod iter;
+mod match_bitflag;
 mod parser;
 mod remove;
 mod symmetric_difference;

--- a/src/tests/match_bitflag.rs
+++ b/src/tests/match_bitflag.rs
@@ -1,0 +1,95 @@
+use super::*;
+
+bitflags! {
+    #[derive(PartialEq)]
+    struct Flags: u8 {
+        const A = 1 << 0;
+        const B = 1 << 1;
+        const C = 1 << 2;
+        const D = 1 << 3;
+    }
+}
+
+fn flag_to_string(flag: Flags) -> String {
+    match_bitflag!(flag, {
+        Flags::A => "A".to_string(),
+        Flags::B => "B".to_string(),
+        Flags::C => "C".to_string(),
+        Flags::D => "D".to_string(),
+        Flags::A | Flags::B => "A or B".to_string(),
+        Flags::A & Flags::B => "A and B | empty".to_string(),
+        Flags::A ^ Flags::B => "A xor B".to_string(),
+        Flags::A | Flags::B | Flags::C => "A or B or C".to_string(),
+        Flags::A & Flags::B & Flags::C => "A and B and C".to_string(),
+        Flags::A ^ Flags::B ^ Flags::C => "A xor B xor C".to_string(),
+        Flags::A | Flags::B | Flags::C | Flags::D => "All flags".to_string(),
+        _ => "Unknown combination".to_string()
+    })
+}
+
+#[test]
+fn test_single_flags() {
+    assert_eq!(flag_to_string(Flags::A), "A");
+    assert_eq!(flag_to_string(Flags::B), "B");
+    assert_eq!(flag_to_string(Flags::C), "C");
+    assert_eq!(flag_to_string(Flags::D), "D");
+}
+
+#[test]
+fn test_or_operations() {
+    assert_eq!(flag_to_string(Flags::A | Flags::B), "A or B");
+    assert_eq!(
+        flag_to_string(Flags::A | Flags::B | Flags::C),
+        "A or B or C"
+    );
+    assert_eq!(
+        flag_to_string(Flags::A | Flags::B | Flags::C | Flags::D),
+        "All flags"
+    );
+}
+
+#[test]
+fn test_and_operations() {
+    assert_eq!(flag_to_string(Flags::A & Flags::A), "A");
+    assert_eq!(flag_to_string(Flags::A & Flags::B), "A and B | empty");
+    assert_eq!(
+        flag_to_string(Flags::A & Flags::B & Flags::C),
+        "A and B | empty"
+    ); // Since A, B, and C are mutually exclusive, the result of A & B & C is 0 ==> A & B & C = 0000 (i.e., empty).
+       // However, in the match_bitflag! statement (actually is if {..} else if {..} .. else {..}),
+       // the "A & B = 0000" condition is listed first, so 0000 will match "A & B" first,
+       // resulting in the output of the "A and B | empty" branch.
+    assert_eq!(
+        flag_to_string(Flags::A & Flags::B & Flags::C & Flags::D),
+        "A and B | empty"
+    );
+}
+
+#[test]
+fn test_xor_operations() {
+    assert_eq!(flag_to_string(Flags::A ^ Flags::B), "A or B"); // A | B = A ^ B == 0011
+    assert_eq!(flag_to_string(Flags::A ^ Flags::A), "A and B | empty");
+    assert_eq!(
+        flag_to_string(Flags::A ^ Flags::B ^ Flags::C),
+        "A or B or C"
+    );
+}
+
+#[test]
+fn test_complex_operations() {
+    assert_eq!(flag_to_string(Flags::A | (Flags::B & Flags::C)), "A");
+    assert_eq!(
+        flag_to_string((Flags::A | Flags::B) & (Flags::B | Flags::C)),
+        "B"
+    );
+    assert_eq!(
+        flag_to_string(Flags::A ^ (Flags::B | Flags::C)),
+        "A or B or C"
+    );
+}
+
+#[test]
+fn test_empty_and_full_flags() {
+    assert_eq!(flag_to_string(Flags::empty()), "A and B | empty");
+    assert_eq!(flag_to_string(Flags::all()), "All flags");
+}


### PR DESCRIPTION
I encountered an “unreachable” issue while utilizing Rust’s match statement. In search of a more effective solution, I considered employing a macro. However, I found that there wasn’t an existing macro to address this issue. Consequently, I decided to create one myself. 

Could you please review my code? I’m looking for feedback and suggestions. If you find it beneficial and suitable, I would appreciate it if you could merge it. Thank you.

related issues: 
1. #201 
2. #375 
3. ...

--- 

Implemented a new macro, `match_bitflag`, to perform matching operations on bitflags, similar to Rust's match expression. This macro addresses the matching issues that arise when using regular match expressions with bitflags.

- The macro supports complex bitflag combination matching.
- Added unit tests to verify the correctness of the macro.
- Provided usage examples and an explanation of the macro's internal implementation.

```rust
/// Match bitflag patterns similar to Rust's match expression
///
/// This macro allows for matching bitflag combinations in a way that resembles
/// Rust's native match expression, but works correctly with bitflag operations.
///
/// # Requirements
///
/// - The struct used with this macro must implement `PartialEq`.
/// - It's recommended to use this macro with structs created by the `bitflags!` macro.
///
/// # Syntax
///
/// ```ignore
/// match_bitflag!(expression, {
///     pattern1 => result1,
///     pattern2 => result2,
///     ...
///     _ => default_result
/// })
/// ```
///
/// # Examples
///
/// ```rust
/// use bitflags::{match_bitflag, bitflags};
///
/// bitflags! {
///     #[derive(PartialEq)]
///     struct Flags: u8 {
///         const A = 1 << 0;
///         const B = 1 << 1;
///         const C = 1 << 2;
///     }
/// }
///
/// let flags = Flags::A | Flags::B;
///
/// match_bitflag!(expected, {
///     Flags::A => println!("A"),
///     Flags::B => println!("B"),
///     Flags::C  => println!("C"),
///     Flags::A | Flags::B =>{
///          // println!("A | B");
///          print!("A");
///          print!(" | ");
///          print!("B");
///     },
///     Flags::A | Flags::C => println!("A | C"),
///     Flags::B | Flags::C => println!("B | C"),
///     Flags::A | Flags::B | Flags::C => println!("A | B | C"),
///     _ => println!("other")
/// })
/// ```
///
/// # How it works
///
/// The macro expands to a series of if-else statements, checking equality
/// between the input expression and each pattern. This allows for correct
/// matching of bitflag combinations, which is not possible with a regular
/// match expression due to the way bitflags are implemented.
///
/// # Note
///
/// The order of patterns matters. The first matching pattern will be executed,
/// so more specific patterns should come before more general ones.
#[macro_export]
macro_rules! match_bitflag {
    ($operation:expr, {
    $( $pattern:expr => $result:expr, )*
        _ => $default:expr
    }) => {
        {
            $(
                if $operation == $pattern {
                    $result
                } else
            )*
            {
                $default
            }
        }
    };
}
```