### PR TITLE
Add method to check if unknown bits are set

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -22,6 +22,7 @@ mod parser;
 mod remove;
 mod symmetric_difference;
 mod union;
+mod unknown;
 
 bitflags! {
     #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]

--- a/src/tests/unknown.rs
+++ b/src/tests/unknown.rs
@@ -1,0 +1,40 @@
+use super::*;
+
+use crate::Flags;
+
+#[test]
+fn cases() {
+    case(false, TestFlags::empty(), TestFlags::contains_unknown_bits);
+    case(false, TestFlags::A, TestFlags::contains_unknown_bits);
+
+    case(
+        true,
+        TestFlags::ABC | TestFlags::from_bits_retain(1 << 3),
+        TestFlags::contains_unknown_bits,
+    );
+
+    case(
+        true,
+        TestFlags::empty() | TestFlags::from_bits_retain(1 << 3),
+        TestFlags::contains_unknown_bits,
+    );
+
+    case(false, TestFlags::all(), TestFlags::contains_unknown_bits);
+
+    case(false, TestZero::empty(), TestZero::contains_unknown_bits);
+}
+#[track_caller]
+fn case<T: Flags + std::fmt::Debug>(expected: bool, value: T, inherent: impl FnOnce(&T) -> bool) {
+    assert_eq!(
+        expected,
+        inherent(&value),
+        "{:?}.contains_unknown_bits()",
+        value
+    );
+    assert_eq!(
+        expected,
+        Flags::contains_unknown_bits(&value),
+        "Flags::contains_unknown_bits({:?})",
+        value
+    );
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -152,6 +152,11 @@ pub trait Flags: Sized + 'static {
         Self::from_bits_retain(truncated)
     }
 
+    /// This method will return `true` if any unknown bits are set.
+    fn contains_unknown_bits(&self) -> bool {
+        Self::all().bits() & self.bits() != self.bits()
+    }
+
     /// Get the underlying bits value.
     ///
     /// The returned value is exactly the bits set in this flags value.


### PR DESCRIPTION
This PR adds a method to the `Flags` trait, `contains_unknown_bits(&self)`, to check whether any unknown bits are set (See #425). It also adds tests for this method.