### PR TITLE
Add `truncate(&mut self)` method to unset unknown bits

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,6 +21,7 @@ mod iter;
 mod parser;
 mod remove;
 mod symmetric_difference;
+mod truncate;
 mod union;
 mod unknown;
 

--- a/src/tests/truncate.rs
+++ b/src/tests/truncate.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+use crate::Flags;
+
+#[test]
+fn cases() {
+    case(
+        TestFlags::ABC | TestFlags::from_bits_retain(1 << 3),
+        TestFlags::ABC,
+    );
+
+    case(TestZero::empty(), TestZero::empty());
+
+    case(TestZero::all(), TestZero::all());
+
+    case(
+        TestFlags::from_bits_retain(1 << 3) | TestFlags::all(),
+        TestFlags::all(),
+    );
+}
+
+#[track_caller]
+fn case<T: Flags + std::fmt::Debug>(mut before: T, after: T)
+where
+    T: std::fmt::Debug + PartialEq + Copy,
+{
+    before.truncate();
+    assert_eq!(before, after, "{:?}.truncate()", before);
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -246,6 +246,14 @@ pub trait Flags: Sized + 'static {
         self.bits() & other.bits() == other.bits()
     }
 
+    /// Remove any unknown bits from the flags.
+    fn truncate(&mut self)
+    where
+        Self: Sized,
+    {
+        *self = Self::from_bits_truncate(self.bits());
+    }
+
     /// The bitwise or (`|`) of the bits in two flags values.
     fn insert(&mut self, other: Self)
     where


### PR DESCRIPTION
Hi,

This PR adds the method `truncate(&mut self)` to the `Flags` trait (see #425), which unsets any unknown bits. It also adds some tests for this method.