### PR TITLE
Prepare for 2.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 2.7.0
+
+## What's Changed
+* Fix `clippy::doc_lazy_continuation` lints by @waywardmonkeys in https://github.com/bitflags/bitflags/pull/414
+* Run clippy on extra features in CI. by @waywardmonkeys in https://github.com/bitflags/bitflags/pull/415
+* Fix CI: trybuild refresh, allow some clippy restrictions. by @waywardmonkeys in https://github.com/bitflags/bitflags/pull/417
+* Update zerocopy version in example by @KodrAus in https://github.com/bitflags/bitflags/pull/422
+* Add method to check if unknown bits are set by @wysiwys in https://github.com/bitflags/bitflags/pull/426
+* Update error messages by @KodrAus in https://github.com/bitflags/bitflags/pull/427
+* Add `truncate(&mut self)` method to unset unknown bits by @wysiwys in https://github.com/bitflags/bitflags/pull/428
+* Update error messages by @KodrAus in https://github.com/bitflags/bitflags/pull/429
+
+## New Contributors
+* @wysiwys made their first contribution in https://github.com/bitflags/bitflags/pull/426
+
+**Full Changelog**: https://github.com/bitflags/bitflags/compare/2.6.0...2.7.0
+
 # 2.6.0
 
 ## What's Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitflags"
 # NB: When modifying, also modify the number in readme (for breaking changes)
-version = "2.6.0"
+version = "2.7.0"
 edition = "2021"
 rust-version = "1.56.0"
 authors = ["The Rust Project Developers"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bitflags = "2.6.0"
+bitflags = "2.7.0"
 ```
 
 and this to your source code:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ Add `bitflags` to your `Cargo.toml`:
 
 ```toml
 [dependencies.bitflags]
-version = "2.6.0"
+version = "2.7.0"
 ```
 
 ## Generating flags types


### PR DESCRIPTION
## What's Changed
* Fix `clippy::doc_lazy_continuation` lints by @waywardmonkeys in https://github.com/bitflags/bitflags/pull/414
* Run clippy on extra features in CI. by @waywardmonkeys in https://github.com/bitflags/bitflags/pull/415
* Fix CI: trybuild refresh, allow some clippy restrictions. by @waywardmonkeys in https://github.com/bitflags/bitflags/pull/417
* Update zerocopy version in example by @KodrAus in https://github.com/bitflags/bitflags/pull/422
* Add method to check if unknown bits are set by @wysiwys in https://github.com/bitflags/bitflags/pull/426
* Update error messages by @KodrAus in https://github.com/bitflags/bitflags/pull/427
* Add `truncate(&mut self)` method to unset unknown bits by @wysiwys in https://github.com/bitflags/bitflags/pull/428
* Update error messages by @KodrAus in https://github.com/bitflags/bitflags/pull/429