### PR TITLE
Pin checkout action for miri job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,7 +102,7 @@ jobs:
     name: "Miri"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: Install Miri
         run: |
           rustup toolchain install nightly --component miri


### PR DESCRIPTION
This PR just gets the Miri CI job lined up with the way the others work