### PR TITLE
`Flags` trait: add `clear(&mut self)` method

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,7 @@
 mod all;
 mod bitflags_match;
 mod bits;
+mod clear;
 mod complement;
 mod contains;
 mod difference;

--- a/src/tests/clear.rs
+++ b/src/tests/clear.rs
@@ -1,0 +1,27 @@
+use super::*;
+
+use crate::Flags;
+
+#[test]
+fn cases() {
+    case(TestFlags::from_bits_retain(0));
+
+    case(TestFlags::from_bits_retain(1 << 3));
+
+    case(TestFlags::ABC | TestFlags::from_bits_retain(1 << 3));
+
+    case(TestZero::empty());
+
+    case(TestZero::all());
+
+    case(TestFlags::from_bits_retain(1 << 3) | TestFlags::all());
+}
+
+#[track_caller]
+fn case<T: Flags + std::fmt::Debug>(mut flags: T)
+where
+    T: std::fmt::Debug + PartialEq + Copy,
+{
+    flags.clear();
+    assert_eq!(flags, T::empty(), "{:?}.clear()", flags);
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -293,6 +293,14 @@ pub trait Flags: Sized + 'static {
         }
     }
 
+    /// Unsets all bits in the flags.
+    fn clear(&mut self)
+    where
+        Self: Sized,
+    {
+        *self = Self::empty();
+    }
+
     /// The bitwise and (`&`) of the bits in two flags values.
     #[must_use]
     fn intersection(self, other: Self) -> Self {


### PR DESCRIPTION
This pull request adds a method to the `Flags` trait that clears all set bits in the flags. Resolves #418.
