### PR TITLE
Prepare for 2.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 2.9.0
+
+## What's Changed
+* `Flags` trait: add `clear(&mut self)` method by @wysiwys in https://github.com/bitflags/bitflags/pull/437
+* Fix up UI tests by @KodrAus in https://github.com/bitflags/bitflags/pull/438
+
+
+**Full Changelog**: https://github.com/bitflags/bitflags/compare/2.8.0...2.9.0
+
 # 2.8.0
 
 ## What's Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitflags"
 # NB: When modifying, also modify the number in readme (for breaking changes)
-version = "2.8.0"
+version = "2.9.0"
 edition = "2021"
 rust-version = "1.56.0"
 authors = ["The Rust Project Developers"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bitflags = "2.8.0"
+bitflags = "2.9.0"
 ```
 
 and this to your source code:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ Add `bitflags` to your `Cargo.toml`:
 
 ```toml
 [dependencies.bitflags]
-version = "2.8.0"
+version = "2.9.0"
 ```
 
 ## Generating flags types


### PR DESCRIPTION
## What's Changed
* `Flags` trait: add `clear(&mut self)` method by @wysiwys in https://github.com/bitflags/bitflags/pull/437
* Fix up UI tests by @KodrAus in https://github.com/bitflags/bitflags/pull/438


**Full Changelog**: https://github.com/bitflags/bitflags/compare/2.8.0...2.9.0