### PR TITLE
Fix difference in the spec

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,9 +108,9 @@ jobs:
           rustup toolchain install nightly --component miri
           cargo +nightly miri setup
       - name: Default features
-        run: cargo +nightly miri test
+        run: cargo +nightly miri test --lib
       - name: BE
-        run: cargo +nightly miri test --target s390x-unknown-linux-gnu
+        run: cargo +nightly miri test --lib --target s390x-unknown-linux-gnu
 
   clippy:
     name: Clippy

--- a/spec.md
+++ b/spec.md
@@ -397,6 +397,10 @@ The bitwise negation (`!`) of the bits in a flags value, truncating the result.
 
 ----
 
+The complement is the only operation that explicitly truncates its result, because it doesn't accept a second flags value as input and so is likely to set unknown bits.
+
+----
+
 The following are examples of the complement of a flags value:
 
 ```rust
@@ -407,12 +411,12 @@ The following are examples of the complement of a flags value:
 
 #### Difference
 
-The bitwise union (`|`) of the bits in one flags value and the bitwise negation (`!`) of the bits in another.
+The bitwise intersection (`&`) of the bits in one flags value and the bitwise negation (`!`) of the bits in another.
 
 ----
 
 This operation is not equivalent to the intersection of one flags value with the complement of another (`&!`).
-The former will truncate the result, where difference will not.
+The former will truncate the result in the complement, where difference will not.
 
 ----
 


### PR DESCRIPTION
I just noticed the spec defines _difference_ as `a | !b`, which is wrong. It's `a & !b`.