### PR TITLE
Streamline generated code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -604,28 +604,31 @@ macro_rules! bitflags {
 #[doc(hidden)]
 macro_rules! __impl_bitflags {
     (
+        // These param names must be passed in to make the macro work.
+        // Just use `params: self, bits, name, other, value;`.
+        params: $self:ident, $bits:ident, $name:ident, $other:ident, $value:ident;
         $(#[$outer:meta])*
         $PublicBitFlags:ident: $T:ty {
-            fn empty() $empty:block
-            fn all() $all:block
-            fn bits($bits0:ident) $bits:block
-            fn from_bits($from_bits0:ident) $from_bits:block
-            fn from_bits_truncate($from_bits_truncate0:ident) $from_bits_truncate:block
-            fn from_bits_retain($from_bits_retain0:ident) $from_bits_retain:block
-            fn from_name($from_name0:ident) $from_name:block
-            fn is_empty($is_empty0:ident) $is_empty:block
-            fn is_all($is_all0:ident) $is_all:block
-            fn intersects($intersects0:ident, $intersects1:ident) $intersects:block
-            fn contains($contains0:ident, $contains1:ident) $contains:block
-            fn insert($insert0:ident, $insert1:ident) $insert:block
-            fn remove($remove0:ident, $remove1:ident) $remove:block
-            fn toggle($toggle0:ident, $toggle1:ident) $toggle:block
-            fn set($set0:ident, $set1:ident, $set2:ident) $set:block
-            fn intersection($intersection0:ident, $intersection1:ident) $intersection:block
-            fn union($union0:ident, $union1:ident) $union:block
-            fn difference($difference0:ident, $difference1:ident) $difference:block
-            fn symmetric_difference($symmetric_difference0:ident, $symmetric_difference1:ident) $symmetric_difference:block
-            fn complement($complement0:ident) $complement:block
+            fn empty() $empty_body:block
+            fn all() $all_body:block
+            fn bits(&self) $bits_body:block
+            fn from_bits(bits) $from_bits_body:block
+            fn from_bits_truncate(bits) $from_bits_truncate_body:block
+            fn from_bits_retain(bits) $from_bits_retain_body:block
+            fn from_name(name) $from_name_body:block
+            fn is_empty(&self) $is_empty_body:block
+            fn is_all(&self) $is_all_body:block
+            fn intersects(&self, other) $intersects_body:block
+            fn contains(&self, other) $contains_body:block
+            fn insert(&mut self, other) $insert_body:block
+            fn remove(&mut self, other) $remove_body:block
+            fn toggle(&mut self, other) $toggle_body:block
+            fn set(&mut self, other, value) $set_body:block
+            fn intersection(self, other) $intersection_body:block
+            fn union(self, other) $union_body:block
+            fn difference(self, other) $difference_body:block
+            fn symmetric_difference(self, other) $symmetric_difference_body:block
+            fn complement(self) $complement_body:block
         }
     ) => {
         #[allow(dead_code, deprecated, unused_attributes)]
@@ -633,170 +636,123 @@ macro_rules! __impl_bitflags {
         impl $PublicBitFlags {
             /// Get a flags value with all bits unset.
             #[inline]
-            pub const fn empty() -> Self {
-                $empty
-            }
+            pub const fn empty() -> Self
+                $empty_body
 
             /// Get a flags value with all known bits set.
             #[inline]
-            pub const fn all() -> Self {
-                $all
-            }
+            pub const fn all() -> Self
+                $all_body
 
             /// Get the underlying bits value.
             ///
             /// The returned value is exactly the bits set in this flags value.
             #[inline]
-            pub const fn bits(&self) -> $T {
-                let $bits0 = self;
-                $bits
-            }
+            pub const fn bits(&$self) -> $T
+                $bits_body
 
             /// Convert from a bits value.
             ///
             /// This method will return `None` if any unknown bits are set.
             #[inline]
-            pub const fn from_bits(bits: $T) -> $crate::__private::core::option::Option<Self> {
-                let $from_bits0 = bits;
-                $from_bits
-            }
+            pub const fn from_bits($bits: $T) -> $crate::__private::core::option::Option<Self>
+                $from_bits_body
 
             /// Convert from a bits value, unsetting any unknown bits.
             #[inline]
-            pub const fn from_bits_truncate(bits: $T) -> Self {
-                let $from_bits_truncate0 = bits;
-                $from_bits_truncate
-            }
+            pub const fn from_bits_truncate($bits: $T) -> Self
+                $from_bits_truncate_body
 
             /// Convert from a bits value exactly.
             #[inline]
-            pub const fn from_bits_retain(bits: $T) -> Self {
-                let $from_bits_retain0 = bits;
-                $from_bits_retain
-            }
+            pub const fn from_bits_retain($bits: $T) -> Self
+                $from_bits_retain_body
 
             /// Get a flags value with the bits of a flag with the given name set.
             ///
             /// This method will return `None` if `name` is empty or doesn't
             /// correspond to any named flag.
             #[inline]
-            pub fn from_name(name: &str) -> $crate::__private::core::option::Option<Self> {
-                let $from_name0 = name;
-                $from_name
-            }
+            pub fn from_name($name: &str) -> $crate::__private::core::option::Option<Self>
+                $from_name_body
 
             /// Whether all bits in this flags value are unset.
             #[inline]
-            pub const fn is_empty(&self) -> bool {
-                let $is_empty0 = self;
-                $is_empty
-            }
+            pub const fn is_empty(&$self) -> bool
+                $is_empty_body
 
             /// Whether all known bits in this flags value are set.
             #[inline]
-            pub const fn is_all(&self) -> bool {
-                let $is_all0 = self;
-                $is_all
-            }
+            pub const fn is_all(&$self) -> bool
+                $is_all_body
 
             /// Whether any set bits in a source flags value are also set in a target flags value.
             #[inline]
-            pub const fn intersects(&self, other: Self) -> bool {
-                let $intersects0 = self;
-                let $intersects1 = other;
-                $intersects
-            }
+            pub const fn intersects(&$self, $other: Self) -> bool
+                $intersects_body
 
             /// Whether all set bits in a source flags value are also set in a target flags value.
             #[inline]
-            pub const fn contains(&self, other: Self) -> bool {
-                let $contains0 = self;
-                let $contains1 = other;
-                $contains
-            }
+            pub const fn contains(&$self, $other: Self) -> bool
+                $contains_body
 
             /// The bitwise or (`|`) of the bits in two flags values.
             #[inline]
-            pub fn insert(&mut self, other: Self) {
-                let $insert0 = self;
-                let $insert1 = other;
-                $insert
-            }
+            pub fn insert(&mut $self, $other: Self)
+                $insert_body
 
-            /// The intersection of a source flags value with the complement of a target flags value (`&!`).
+            /// The intersection of a source flags value with the complement of a target flags
+            /// value (`&!`).
             ///
             /// This method is not equivalent to `self & !other` when `other` has unknown bits set.
             /// `remove` won't truncate `other`, but the `!` operator will.
             #[inline]
-            pub fn remove(&mut self, other: Self) {
-                let $remove0 = self;
-                let $remove1 = other;
-                $remove
-            }
+            pub fn remove(&mut $self, $other: Self)
+                $remove_body
 
             /// The bitwise exclusive-or (`^`) of the bits in two flags values.
             #[inline]
-            pub fn toggle(&mut self, other: Self) {
-                let $toggle0 = self;
-                let $toggle1 = other;
-                $toggle
-            }
+            pub fn toggle(&mut $self, $other: Self)
+                $toggle_body
 
             /// Call `insert` when `value` is `true` or `remove` when `value` is `false`.
             #[inline]
-            pub fn set(&mut self, other: Self, value: bool) {
-                let $set0 = self;
-                let $set1 = other;
-                let $set2 = value;
-                $set
-            }
+            pub fn set(&mut $self, $other: Self, $value: bool)
+                $set_body
 
             /// The bitwise and (`&`) of the bits in two flags values.
             #[inline]
             #[must_use]
-            pub const fn intersection(self, other: Self) -> Self {
-                let $intersection0 = self;
-                let $intersection1 = other;
-                $intersection
-            }
+            pub const fn intersection($self, $other: Self) -> Self
+                $intersection_body
 
             /// The bitwise or (`|`) of the bits in two flags values.
             #[inline]
             #[must_use]
-            pub const fn union(self, other: Self) -> Self {
-                let $union0 = self;
-                let $union1 = other;
-                $union
-            }
+            pub const fn union($self, $other: Self) -> Self
+                $union_body
 
-            /// The intersection of a source flags value with the complement of a target flags value (`&!`).
+            /// The intersection of a source flags value with the complement of a target flags
+            /// value (`&!`).
             ///
             /// This method is not equivalent to `self & !other` when `other` has unknown bits set.
             /// `difference` won't truncate `other`, but the `!` operator will.
             #[inline]
             #[must_use]
-            pub const fn difference(self, other: Self) -> Self {
-                let $difference0 = self;
-                let $difference1 = other;
-                $difference
-            }
+            pub const fn difference($self, $other: Self) -> Self
+                $difference_body
 
             /// The bitwise exclusive-or (`^`) of the bits in two flags values.
             #[inline]
             #[must_use]
-            pub const fn symmetric_difference(self, other: Self) -> Self {
-                let $symmetric_difference0 = self;
-                let $symmetric_difference1 = other;
-                $symmetric_difference
-            }
+            pub const fn symmetric_difference($self, $other: Self) -> Self
+                $symmetric_difference_body
 
             /// The bitwise negation (`!`) of the bits in a flags value, truncating the result.
             #[inline]
             #[must_use]
-            pub const fn complement(self) -> Self {
-                let $complement0 = self;
-                $complement
-            }
+            pub const fn complement($self) -> Self
+                $complement_body
         }
     };
 }

--- a/src/public.rs
+++ b/src/public.rs
@@ -164,7 +164,7 @@ macro_rules! __impl_public_bitflags {
                     )*
 
                     let _ = i;
-                    Self::from_bits_retain(truncated)
+                    Self(truncated)
                 }
 
                 fn bits(&self) {
@@ -182,7 +182,7 @@ macro_rules! __impl_public_bitflags {
                 }
 
                 fn from_bits_truncate(bits) {
-                    Self(bits & Self::all().bits())
+                    Self(bits & Self::all().0)
                 }
 
                 fn from_bits_retain(bits) {
@@ -212,33 +212,33 @@ macro_rules! __impl_public_bitflags {
                 }
 
                 fn is_empty(&self) {
-                    self.bits() == <$T as $crate::Bits>::EMPTY
+                    self.0 == <$T as $crate::Bits>::EMPTY
                 }
 
                 fn is_all(&self) {
                     // NOTE: We check against `Self::all` here, not `Self::Bits::ALL`
                     // because the set of all flags may not use all bits
-                    Self::all().bits() | self.bits() == self.bits()
+                    Self::all().0 | self.0 == self.0
                 }
 
                 fn intersects(&self, other) {
-                    self.bits() & other.bits() != <$T as $crate::Bits>::EMPTY
+                    self.0 & other.0 != <$T as $crate::Bits>::EMPTY
                 }
 
                 fn contains(&self, other) {
-                    self.bits() & other.bits() == other.bits()
+                    self.0 & other.0 == other.0
                 }
 
                 fn insert(&mut self, other) {
-                    *self = Self::from_bits_retain(self.bits()).union(other);
+                    *self = Self(self.0).union(other);
                 }
 
                 fn remove(&mut self, other) {
-                    *self = Self::from_bits_retain(self.bits()).difference(other);
+                    *self = Self(self.0).difference(other);
                 }
 
                 fn toggle(&mut self, other) {
-                    *self = Self::from_bits_retain(self.bits()).symmetric_difference(other);
+                    *self = Self(self.0).symmetric_difference(other);
                 }
 
                 fn set(&mut self, other, value) {
@@ -250,23 +250,23 @@ macro_rules! __impl_public_bitflags {
                 }
 
                 fn intersection(self, other) {
-                    Self::from_bits_retain(self.bits() & other.bits())
+                    Self(self.0 & other.0)
                 }
 
                 fn union(self, other) {
-                    Self::from_bits_retain(self.bits() | other.bits())
+                    Self(self.0 | other.0)
                 }
 
                 fn difference(self, other) {
-                    Self::from_bits_retain(self.bits() & !other.bits())
+                    Self(self.0 & !other.0)
                 }
 
                 fn symmetric_difference(self, other) {
-                    Self::from_bits_retain(self.bits() ^ other.bits())
+                    Self(self.0 ^ other.0)
                 }
 
                 fn complement(self) {
-                    Self::from_bits_truncate(!self.bits())
+                    Self::from_bits_truncate(!self.0)
                 }
             }
         }

--- a/src/public.rs
+++ b/src/public.rs
@@ -30,6 +30,7 @@ macro_rules! __impl_public_bitflags_forward {
         $PublicBitFlags:ident: $T:ty, $InternalBitFlags:ident
     ) => {
         $crate::__impl_bitflags! {
+            params: self, bits, name, other, value;
             $(#[$outer])*
             $PublicBitFlags: $T {
                 fn empty() {
@@ -40,8 +41,8 @@ macro_rules! __impl_public_bitflags_forward {
                     Self($InternalBitFlags::all())
                 }
 
-                fn bits(f) {
-                    f.0.bits()
+                fn bits(&self) {
+                    self.0.bits()
                 }
 
                 fn from_bits(bits) {
@@ -66,56 +67,56 @@ macro_rules! __impl_public_bitflags_forward {
                     }
                 }
 
-                fn is_empty(f) {
-                    f.0.is_empty()
+                fn is_empty(&self) {
+                    self.0.is_empty()
                 }
 
-                fn is_all(f) {
-                    f.0.is_all()
+                fn is_all(&self) {
+                    self.0.is_all()
                 }
 
-                fn intersects(f, other) {
-                    f.0.intersects(other.0)
+                fn intersects(&self, other) {
+                    self.0.intersects(other.0)
                 }
 
-                fn contains(f, other) {
-                    f.0.contains(other.0)
+                fn contains(&self, other) {
+                    self.0.contains(other.0)
                 }
 
-                fn insert(f, other) {
-                    f.0.insert(other.0)
+                fn insert(&mut self, other) {
+                    self.0.insert(other.0)
                 }
 
-                fn remove(f, other) {
-                    f.0.remove(other.0)
+                fn remove(&mut self, other) {
+                    self.0.remove(other.0)
                 }
 
-                fn toggle(f, other) {
-                    f.0.toggle(other.0)
+                fn toggle(&mut self, other) {
+                    self.0.toggle(other.0)
                 }
 
-                fn set(f, other, value) {
-                    f.0.set(other.0, value)
+                fn set(&mut self, other, value) {
+                    self.0.set(other.0, value)
                 }
 
-                fn intersection(f, other) {
-                    Self(f.0.intersection(other.0))
+                fn intersection(self, other) {
+                    Self(self.0.intersection(other.0))
                 }
 
-                fn union(f, other) {
-                    Self(f.0.union(other.0))
+                fn union(self, other) {
+                    Self(self.0.union(other.0))
                 }
 
-                fn difference(f, other) {
-                    Self(f.0.difference(other.0))
+                fn difference(self, other) {
+                    Self(self.0.difference(other.0))
                 }
 
-                fn symmetric_difference(f, other) {
-                    Self(f.0.symmetric_difference(other.0))
+                fn symmetric_difference(self, other) {
+                    Self(self.0.symmetric_difference(other.0))
                 }
 
-                fn complement(f) {
-                    Self(f.0.complement())
+                fn complement(self) {
+                    Self(self.0.complement())
                 }
             }
         }
@@ -139,6 +140,7 @@ macro_rules! __impl_public_bitflags {
         }
     ) => {
         $crate::__impl_bitflags! {
+            params: self, bits, name, other, value;
             $(#[$outer])*
             $BitFlags: $T {
                 fn empty() {
@@ -165,8 +167,8 @@ macro_rules! __impl_public_bitflags {
                     Self::from_bits_retain(truncated)
                 }
 
-                fn bits(f) {
-                    f.0
+                fn bits(&self) {
+                    self.0
                 }
 
                 fn from_bits(bits) {
@@ -209,62 +211,62 @@ macro_rules! __impl_public_bitflags {
                     $crate::__private::core::option::Option::None
                 }
 
-                fn is_empty(f) {
-                    f.bits() == <$T as $crate::Bits>::EMPTY
+                fn is_empty(&self) {
+                    self.bits() == <$T as $crate::Bits>::EMPTY
                 }
 
-                fn is_all(f) {
+                fn is_all(&self) {
                     // NOTE: We check against `Self::all` here, not `Self::Bits::ALL`
                     // because the set of all flags may not use all bits
-                    Self::all().bits() | f.bits() == f.bits()
+                    Self::all().bits() | self.bits() == self.bits()
                 }
 
-                fn intersects(f, other) {
-                    f.bits() & other.bits() != <$T as $crate::Bits>::EMPTY
+                fn intersects(&self, other) {
+                    self.bits() & other.bits() != <$T as $crate::Bits>::EMPTY
                 }
 
-                fn contains(f, other) {
-                    f.bits() & other.bits() == other.bits()
+                fn contains(&self, other) {
+                    self.bits() & other.bits() == other.bits()
                 }
 
-                fn insert(f, other) {
-                    *f = Self::from_bits_retain(f.bits()).union(other);
+                fn insert(&mut self, other) {
+                    *self = Self::from_bits_retain(self.bits()).union(other);
                 }
 
-                fn remove(f, other) {
-                    *f = Self::from_bits_retain(f.bits()).difference(other);
+                fn remove(&mut self, other) {
+                    *self = Self::from_bits_retain(self.bits()).difference(other);
                 }
 
-                fn toggle(f, other) {
-                    *f = Self::from_bits_retain(f.bits()).symmetric_difference(other);
+                fn toggle(&mut self, other) {
+                    *self = Self::from_bits_retain(self.bits()).symmetric_difference(other);
                 }
 
-                fn set(f, other, value) {
+                fn set(&mut self, other, value) {
                     if value {
-                        f.insert(other);
+                        self.insert(other);
                     } else {
-                        f.remove(other);
+                        self.remove(other);
                     }
                 }
 
-                fn intersection(f, other) {
-                    Self::from_bits_retain(f.bits() & other.bits())
+                fn intersection(self, other) {
+                    Self::from_bits_retain(self.bits() & other.bits())
                 }
 
-                fn union(f, other) {
-                    Self::from_bits_retain(f.bits() | other.bits())
+                fn union(self, other) {
+                    Self::from_bits_retain(self.bits() | other.bits())
                 }
 
-                fn difference(f, other) {
-                    Self::from_bits_retain(f.bits() & !other.bits())
+                fn difference(self, other) {
+                    Self::from_bits_retain(self.bits() & !other.bits())
                 }
 
-                fn symmetric_difference(f, other) {
-                    Self::from_bits_retain(f.bits() ^ other.bits())
+                fn symmetric_difference(self, other) {
+                    Self::from_bits_retain(self.bits() ^ other.bits())
                 }
 
-                fn complement(f) {
-                    Self::from_bits_truncate(!f.bits())
+                fn complement(self) {
+                    Self::from_bits_truncate(!self.bits())
                 }
             }
         }


### PR DESCRIPTION
Some minor improvements to the generated code. In a stress test containing 100 invocations like `bitflags! { struct F1: u32 { const A = 0b1; const B = 0b10; } }` this reduced compile times by about 10%. The generated machine code is also a bit better in dev builds.