### PR TITLE
Add Cargo features to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ fn main() {
 }
 ```
 
+## Cargo features
+
+The `bitflags` library defines a few Cargo features that you can opt-in to:
+
+- `std`: Implement the `Error` trait on error types used by `bitflags`.
+- `serde`: Support deriving `serde` traits on generated flags types.
+- `arbitrary`: Support deriving `arbitrary` traits on generated flags types.
+- `bytemuck`: Support deriving `bytemuck` traits on generated flags types.
+
+Also see [`bitflags_derive`](https://github.com/bitflags/bitflags-derive) for other flags-aware traits.
+
 ## Rust Version Support
 
 The minimum supported Rust version is documented in the `Cargo.toml` file.


### PR DESCRIPTION
Closes #457

This PR just adds the list of supported Cargo features to the README to make them more discoverable. They're already in the library docs themselves, but there's a lot of info in there already so they're a bit buried.