### PR TITLE
Use serde_core instead of serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ A macro to generate structures which behave like bitflags.
 exclude = ["/tests", "/.github"]
 
 [dependencies]
-serde = { version = "1.0.103", optional = true, default-features = false }
+serde_core = { version = "1.0.103", optional = true, default-features = false }
 arbitrary = { version = "1.0", optional = true }
 bytemuck = { version = "1.12", optional = true }
 
 [dev-dependencies]
 trybuild = "1.0.18"
 rustversion = "1.0"
-serde_derive = "1.0.103"
+serde = { version = "1.0.103", features = ["derive"] }
 serde_json = "1.0"
 serde_test = "1.0.19"
 zerocopy = { version = "0.8", features = ["derive"] }
@@ -35,6 +35,7 @@ bytemuck = { version = "1.12.2", features = ["derive"] }
 [features]
 std = []
 example_generated = []
+serde = ["dep:serde_core"]
 
 [package.metadata.docs.rs]
 features = ["example_generated"]

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -4,7 +4,7 @@
 
 #[cfg(feature = "serde")]
 fn main() {
-    use serde_derive::*;
+    use serde::*;
 
     bitflags::bitflags! {
         #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/src/external.rs
+++ b/src/external.rs
@@ -67,7 +67,7 @@ __impl_external_bitflags_my_library! {
 
 pub(crate) mod __private {
     #[cfg(feature = "serde")]
-    pub use serde;
+    pub use serde_core as serde;
 
     #[cfg(feature = "arbitrary")]
     pub use arbitrary;
@@ -155,7 +155,7 @@ macro_rules! __impl_external_bitflags_serde {
             ) -> $crate::__private::core::result::Result<Self, D::Error> {
                 let flags: $PublicBitFlags = $crate::serde::deserialize(deserializer)?;
 
-                Ok(flags.0)
+                $crate::__private::core::result::Result::Ok(flags.0)
             }
         }
     };

--- a/src/external/serde.rs
+++ b/src/external/serde.rs
@@ -5,7 +5,7 @@ use crate::{
     Flags,
 };
 use core::{fmt, str};
-use serde::{
+use serde_core::{
     de::{Error, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
@@ -70,7 +70,7 @@ where
 mod tests {
     use serde_test::{assert_tokens, Configure, Token::*};
     bitflags! {
-        #[derive(serde_derive::Serialize, serde_derive::Deserialize, Debug, PartialEq, Eq)]
+        #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
         #[serde(transparent)]
         struct SerdeFlags: u32 {
             const A = 1;


### PR DESCRIPTION
Serde recently split out the trait definitions from the top level serde crate. This crate does not rely on the derive macro, so it should be effective to depend on serde_core instead of serde. This doesn't impact the compilation times of glam itself, but allows it to parallelize with `serde-derive` and potentially other crates like `serde-json` that also do not rely on the derive macro, unblocking other crates reliant on bitflags to do so as well.