### PR TITLE
Implement iterator for all named flags

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -152,6 +152,14 @@ pub trait Flags: Sized + 'static {
         Self::from_bits_retain(truncated)
     }
 
+    /// This method will return an iterator over all named flags (including combinations).
+    fn all_named_flags() -> impl Iterator<Item = Self> {
+        Self::FLAGS
+            .iter()
+            .filter(|f| f.is_named())
+            .map(|f| Self::from_bits_retain(f.value().bits()))
+    }
+
     /// This method will return `true` if any unknown bits are set.
     fn contains_unknown_bits(&self) -> bool {
         Self::all().bits() & self.bits() != self.bits()


### PR DESCRIPTION
Add method to iterate over all named flags.

This test suit passed successfully
```rust
#[test]
fn test_all_named_flags() {
    // use bitflags::bitflags;

    bitflags! {
        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
        struct Flags: u32 {
            const A = 0b00000001;
            const B = 0b00000010;
            const C = 0b00000100;
            const ABC = Self::A.bits() | Self::B.bits() | Self::C.bits();
            const AB = Self::A.bits() | Self::B.bits();
            const AC = Self::A.bits() | Self::C.bits();
            const CB = Self::B.bits() | Self::C.bits();
        }
    }

    for flag in Flags::all_named_flags() {
        println!("{:?}", flag);
    }
}
```
The output is
```

running 1 test
test test_all_named_flags ... ok

successes:

---- test_all_named_flags stdout ----
Flags(A)
Flags(B)
Flags(C)
Flags(A | B | C)
Flags(A | B)
Flags(A | C)
Flags(B | C)


successes:
    test_all_named_flags

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 48 filtered out; finished in 0.00s       
```