### PR TITLE
Depend on serde_core instead of serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,22 +18,23 @@ A macro to generate structures which behave like bitflags.
 exclude = ["/tests", "/.github"]
 
 [dependencies]
-serde = { version = "1.0.103", optional = true, default-features = false }
+serde_core = { version = "1.0.228", optional = true, default-features = false }
 arbitrary = { version = "1.0", optional = true }
 bytemuck = { version = "1.12", optional = true }
 
 [dev-dependencies]
 trybuild = "1.0.18"
 rustversion = "1.0"
-serde_derive = "1.0.103"
 serde_json = "1.0"
 serde_test = "1.0.19"
+serde_lib = { version = "1.0.103", features = ["derive"], package = "serde" }
 zerocopy = { version = "0.8", features = ["derive"] }
 arbitrary = { version = "1.0", features = ["derive"] }
 bytemuck = { version = "1.12.2", features = ["derive"] }
 
 [features]
 std = []
+serde = ["serde_core"]
 example_generated = []
 
 [package.metadata.docs.rs]

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -4,11 +4,14 @@
 
 #[cfg(feature = "serde")]
 fn main() {
-    use serde_derive::*;
+    use serde_lib::*;
 
     bitflags::bitflags! {
         #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
         #[serde(transparent)]
+        // NOTE: We alias the `serde` crate as `serde_lib` in this repository,
+        // but you don't need to do this
+        #[serde(crate = "serde_lib")]
         pub struct Flags: u32 {
             const A = 1;
             const B = 2;

--- a/src/external.rs
+++ b/src/external.rs
@@ -67,7 +67,7 @@ __impl_external_bitflags_my_library! {
 
 pub(crate) mod __private {
     #[cfg(feature = "serde")]
-    pub use serde;
+    pub use serde_core as serde;
 
     #[cfg(feature = "arbitrary")]
     pub use arbitrary;

--- a/src/external/serde.rs
+++ b/src/external/serde.rs
@@ -5,7 +5,7 @@ use crate::{
     Flags,
 };
 use core::{fmt, str};
-use serde::{
+use serde_core::{
     de::{Error, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
@@ -69,9 +69,10 @@ where
 #[cfg(test)]
 mod tests {
     use serde_test::{assert_tokens, Configure, Token::*};
+
     bitflags! {
-        #[derive(serde_derive::Serialize, serde_derive::Deserialize, Debug, PartialEq, Eq)]
-        #[serde(transparent)]
+        #[derive(serde_lib::Serialize, serde_lib::Deserialize, Debug, PartialEq, Eq)]
+        #[serde(crate = "serde_lib", transparent)]
         struct SerdeFlags: u32 {
             const A = 1;
             const B = 2;


### PR DESCRIPTION
This is another attempt at #462. To avoid bumping our MSRV, we need to depend on `serde_core`, but also keep the `serde` feature name. We can't then depend on `serde` itself as a `dev-dependency` because rustc 1.56.0 doesn't support features that share crate names. To make it work we need to make our `serde` example a little less straightforward.