### PR TITLE
Prepare for 2.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2.10.0
+
+## What's Changed
+* Implement iterator for all named flags by @ssrlive in https://github.com/bitflags/bitflags/pull/465
+* Depend on serde_core instead of serde by @KodrAus in https://github.com/bitflags/bitflags/pull/467
+
+## New Contributors
+* @ssrlive made their first contribution in https://github.com/bitflags/bitflags/pull/465
+
+**Full Changelog**: https://github.com/bitflags/bitflags/compare/2.9.4...2.10.0
+
 # 2.9.4
 
 ## What's Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitflags"
 # NB: When modifying, also modify the number in readme (for breaking changes)
-version = "2.9.4"
+version = "2.10.0"
 edition = "2021"
 rust-version = "1.56.0"
 authors = ["The Rust Project Developers"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bitflags = "2.9.4"
+bitflags = "2.10.0"
 ```
 
 and this to your source code:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ Add `bitflags` to your `Cargo.toml`:
 
 ```toml
 [dependencies.bitflags]
-version = "2.9.3"
+version = "2.10.0"
 ```
 
 ## Crate features


### PR DESCRIPTION
## What's Changed
* Implement iterator for all named flags by @ssrlive in https://github.com/bitflags/bitflags/pull/465
* Depend on serde_core instead of serde by @KodrAus in https://github.com/bitflags/bitflags/pull/467

## New Contributors
* @ssrlive made their first contribution in https://github.com/bitflags/bitflags/pull/465

**Full Changelog**: https://github.com/bitflags/bitflags/compare/2.9.4...2.10.0