### PR TITLE
add MyFlags::Abc::iter_equal_names() method

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -180,3 +180,35 @@ impl<B: Flags> Iterator for IterDefinedNames<B> {
         None
     }
 }
+
+/**
+An iterator over all defined names for a specific flags value.
+*/
+pub struct ValueNames<T: Flags> {
+    inner: IterDefinedNames<T>,
+    bits: T::Bits,
+}
+
+impl<T: Flags> ValueNames<T> {
+    #[inline]
+    pub fn new(value: &T) -> Self {
+        Self {
+            inner: <T as Flags>::iter_defined_names(),
+            bits: value.bits(),
+        }
+    }
+}
+
+impl<T: Flags> Iterator for ValueNames<T> {
+    type Item = &'static str;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        for (n, f) in self.inner.by_ref() {
+            if f.bits() == self.bits {
+                return Some(n);
+            }
+        }
+        None
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,6 +532,8 @@ macro_rules! bitflags {
             $crate::__impl_public_bitflags_iter! {
                 $BitFlags: $T, $BitFlags
             }
+
+            $crate::__impl_public_bitflags_name! { $BitFlags }
         };
 
         $crate::bitflags! {
@@ -587,6 +589,8 @@ macro_rules! bitflags {
             $crate::__impl_public_bitflags_iter! {
                 $BitFlags: $T, $BitFlags
             }
+
+            $crate::__impl_public_bitflags_name! { $BitFlags }
         };
 
         $crate::bitflags! {
@@ -594,6 +598,24 @@ macro_rules! bitflags {
         }
     };
     () => {};
+}
+
+/// Implementing name/try_name based on FLAGS
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __impl_public_bitflags_name {
+    ($BitFlags:ident) => {
+        impl $BitFlags {
+            /// Get an iterator over all defined names for this flags value.
+            ///
+            /// This iterator will yield all defined names for the flags value, including
+            /// any convenience flags.
+            #[inline]
+            pub fn names(&self) -> $crate::iter::ValueNames<$BitFlags> {
+                $crate::iter::ValueNames::new(self)
+            }
+        }
+    };
 }
 
 /// Implement functions on bitflags types.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -26,6 +26,7 @@ mod symmetric_difference;
 mod truncate;
 mod union;
 mod unknown;
+mod value_names;
 
 bitflags! {
     #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]

--- a/src/tests/value_names.rs
+++ b/src/tests/value_names.rs
@@ -1,0 +1,37 @@
+#[test]
+fn test_value_names() {
+    bitflags! {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        struct TestFlags: u32 {
+            const A = 0b00000001;
+            const ZERO = 0;
+            const B = 0b00000010;
+            const C = 0b00000100;
+            const CC = Self::C.bits();
+            const D = 0b10000100;
+            const ABC = Self::A.bits() | Self::B.bits() | Self::C.bits();
+            const AB = Self::A.bits() | Self::B.bits();
+            const AC = Self::A.bits() | Self::C.bits();
+            const CB = Self::B.bits() | Self::C.bits();
+        }
+    }
+
+    assert_eq!(TestFlags::A.names().collect::<Vec<_>>(), vec!["A"]);
+    assert_eq!(TestFlags::ZERO.names().collect::<Vec<_>>(), vec!["ZERO"]);
+    assert_eq!(TestFlags::B.names().collect::<Vec<_>>(), vec!["B"]);
+
+    assert_eq!(TestFlags::C.names().collect::<Vec<_>>(), vec!["C", "CC"]);
+    assert!(TestFlags::C.names().any(|n| n == "CC" || n == "C"));
+
+    assert_eq!(TestFlags::CC.names().collect::<Vec<_>>(), vec!["C", "CC"]);
+    assert!(TestFlags::CC.names().any(|n| n == "CC" || n == "C"));
+
+    assert_eq!(TestFlags::D.names().collect::<Vec<_>>(), vec!["D"]);
+    assert_eq!(TestFlags::ABC.names().collect::<Vec<_>>(), vec!["ABC"]);
+    assert_eq!(TestFlags::AB.names().collect::<Vec<_>>(), vec!["AB"]);
+    assert_eq!(TestFlags::AC.names().collect::<Vec<_>>(), vec!["AC"]);
+    assert_eq!(TestFlags::CB.names().collect::<Vec<_>>(), vec!["CB"]);
+
+    let xyz = TestFlags::from_bits_retain(123456);
+    assert!(xyz.names().collect::<Vec<_>>().is_empty());
+}

--- a/tests/compile-fail/bitflags_redefined.stderr
+++ b/tests/compile-fail/bitflags_redefined.stderr
@@ -803,6 +803,25 @@ error[E0592]: duplicate definitions with name `iter_names`
    |
    = note: this error originates in the macro `$crate::__impl_public_bitflags_iter` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error[E0592]: duplicate definitions with name `names`
+  --> tests/compile-fail/bitflags_redefined.rs:4:1
+   |
+ 4 | / bitflags! {
+ 5 | |     pub struct Flags1: u32 {
+ 6 | |         const A = 1;
+ 7 | |     }
+ 8 | | }
+   | |_^ duplicate definitions for `names`
+ 9 |
+10 | / bitflags! {
+11 | |     pub struct Flags1: u32 {
+12 | |         const A = 1;
+13 | |     }
+14 | | }
+   | |_- other definition for `names`
+   |
+   = note: this error originates in the macro `$crate::__impl_public_bitflags_name` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0034]: multiple applicable items in scope
   --> tests/compile-fail/bitflags_redefined.rs:4:1
    |


### PR DESCRIPTION
Sometimes we need to retrieve the string names of the Flags values ​​we defined, so I added the method `names`.