### PR TITLE
Add a custom `#[flag_name]` attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -860,7 +860,7 @@ macro_rules! __bitflags_match {
     }
 }
 
-/// A macro that processed the input to `bitflags!` and shuffles attributes around
+/// A macro that processes the input to `bitflags!` and shuffles attributes around
 /// based on whether or not they're "expression-safe".
 ///
 /// This macro is a token-tree muncher that works on 2 levels:
@@ -919,6 +919,31 @@ macro_rules! __bitflags_expr_safe_attrs {
         }
     };
     // Process the next attribute on the current flag
+    // The `flag_name` attribute is custom, so is discarded
+    (
+        expr: { $e:expr },
+            attrs: {
+            unprocessed: [
+                // cfg matched here
+                #[flag_name $($args:tt)*]
+                $($attrs_rest:tt)*
+            ],
+            processed: [$($expr:tt)*],
+        },
+    ) => {
+        $crate::__bitflags_expr_safe_attrs! {
+            expr: { $e },
+            attrs: {
+                unprocessed: [
+                    $($attrs_rest)*
+                ],
+                processed: [
+                    $($expr)*
+                ],
+            },
+        }
+    };
+    // Process the next attribute on the current flag
     // `$other`: The next flag should not be propagated to expressions
     (
         expr: { $e:expr },
@@ -954,6 +979,157 @@ macro_rules! __bitflags_expr_safe_attrs {
     ) => {
         $(#[$expr $($exprargs)*])*
         { $e }
+    }
+}
+
+/// A macro that processes the input to `bitflags!` and shuffles attributes around
+/// based on whether or not they're "item-safe".
+///
+/// This macro follows the same pattern as expr-safe above, but assumes all attributes
+/// are safe on items. It only filters out any `bitflags`-defined attributes.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __bitflags_item_safe_attrs {
+    // Entrypoint: Move all flags and all attributes into `unprocessed` lists
+    // where they'll be munched one-at-a-time
+    (
+        $(#[$inner:ident $($args:tt)*])*
+        { $i:item }
+    ) => {
+        $crate::__bitflags_item_safe_attrs! {
+            item: { $i },
+            attrs: {
+                // All attributes start here
+                unprocessed: [$(#[$inner $($args)*])*],
+                // Attributes that are safe on items go here
+                processed: [],
+            },
+        }
+    };
+    // Process the next attribute on the current flag
+    // The `flag_name` attribute is custom, so is discarded
+    (
+        item: { $i:item },
+            attrs: {
+            unprocessed: [
+                // cfg matched here
+                #[flag_name $($args:tt)*]
+                $($attrs_rest:tt)*
+            ],
+            processed: [$($item:tt)*],
+        },
+    ) => {
+        $crate::__bitflags_item_safe_attrs! {
+            item: { $i },
+            attrs: {
+                unprocessed: [
+                    $($attrs_rest)*
+                ],
+                processed: [
+                    $($item)*
+                ],
+            },
+        }
+    };
+    // Process the next attribute on the current flag
+    // `$other`: The next flag should not be propagated to items
+    (
+        item: { $i:item },
+            attrs: {
+            unprocessed: [
+                // $other matched here
+                #[$other:ident $($args:tt)*]
+                $($attrs_rest:tt)*
+            ],
+            processed: [$($item:tt)*],
+        },
+    ) => {
+        $crate::__bitflags_item_safe_attrs! {
+            item: { $i },
+                attrs: {
+                unprocessed: [
+                    $($attrs_rest)*
+                ],
+                processed: [
+                    // $other added here
+                    $($item)*
+                    #[$other $($args)*]
+                ],
+            },
+        }
+    };
+    // Once all attributes on all flags are processed, generate the actual code
+    (
+        item: { $i:item },
+        attrs: {
+            unprocessed: [],
+            processed: [$(#[$item:ident $($itemargs:tt)*])*],
+        },
+    ) => {
+        $(#[$item $($itemargs)*])*
+        $i
+    }
+}
+
+/// Determine the name to assign to a flag.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __bitflags_flag_name {
+    // Entrypoint: Move all flags and all attributes into `unprocessed` lists
+    // where they'll be munched one-at-a-time
+    (
+        $(#[$inner:ident $($args:tt)*])*
+        { $name:ident }
+    ) => {
+        $crate::__bitflags_flag_name! {
+            name: { $name },
+            attrs: {
+                // All attributes start here
+                unprocessed: [$(#[$inner $($args)*])*],
+            },
+        }
+    };
+    // Matched `flag_name`
+    (
+        name: { $name:ident },
+            attrs: {
+            unprocessed: [
+                // cfg matched here
+                #[flag_name = $flag_name:tt]
+                $($attrs_rest:tt)*
+            ],
+        },
+    ) => {
+        $flag_name
+    };
+    // Discard other attributes
+    (
+        name: { $name:ident },
+            attrs: {
+            unprocessed: [
+                // $other matched here
+                #[$other:ident $($args:tt)*]
+                $($attrs_rest:tt)*
+            ],
+        },
+    ) => {
+        $crate::__bitflags_flag_name! {
+            name: { $name },
+                attrs: {
+                unprocessed: [
+                    $($attrs_rest)*
+                ],
+            },
+        }
+    };
+    // Finished
+    (
+        name: { $name:ident },
+        attrs: {
+            unprocessed: [],
+        },
+    ) => {
+        $crate::__private::core::stringify!($name)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -947,7 +947,7 @@ macro_rules! __bitflags_expr_safe_attrs {
             attrs: {
             unprocessed: [
                 // flag_name matched here
-                #[flag_name $($args:tt)*]
+                #[flag_name = $arg:tt]
                 $($attrs_rest:tt)*
             ],
             processed: [$($expr:tt)*],
@@ -1035,7 +1035,7 @@ macro_rules! __bitflags_item_safe_attrs {
             attrs: {
             unprocessed: [
                 // flag_name matched here
-                #[flag_name $($args:tt)*]
+                #[flag_name = $arg:tt]
                 $($attrs_rest:tt)*
             ],
             processed: [$($item:tt)*],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,28 @@ impl Flags {
 }
 ```
 
+### Renaming flags
+
+The [`bitflags`] macro recognizes a special `#[flag_name = "<value>"]` attribute on flags values to rename them:
+
+```rust
+# use bitflags::bitflags;
+bitflags! {
+    pub struct Flags: u32 {
+        // Add the attribute to a flag to change its name
+        #[flag_name = "a"]
+        const A = 0b00000001;
+        #[flag_name = "b"]
+        const B = 0b00000010;
+        #[flag_name = "c"]
+        const C = 0b00000100;
+    }
+}
+```
+
+When applied to a flag value, instead of using its identifier, like `A` as the name, it'll use the given string. This
+doesn't affect the identifier of the constant itself, just the name recognized when parsing and formatting.
+
 ## Working with flags values
 
 Use generated constants and standard bitwise operators to interact with flags values:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -947,7 +947,7 @@ macro_rules! __bitflags_expr_safe_attrs {
             attrs: {
             unprocessed: [
                 // flag_name matched here
-                #[flag_name = $arg:tt]
+                #[flag_name = $arg:expr]
                 $($attrs_rest:tt)*
             ],
             processed: [$($expr:tt)*],
@@ -1035,7 +1035,7 @@ macro_rules! __bitflags_item_safe_attrs {
             attrs: {
             unprocessed: [
                 // flag_name matched here
-                #[flag_name = $arg:tt]
+                #[flag_name = $arg:expr]
                 $($attrs_rest:tt)*
             ],
             processed: [$($item:tt)*],
@@ -1117,7 +1117,7 @@ macro_rules! __bitflags_flag_name {
             attrs: {
             unprocessed: [
                 // cfg matched here
-                #[flag_name = $flag_name:tt]
+                #[flag_name = $flag_name:expr]
                 $($attrs_rest:tt)*
             ],
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -924,7 +924,7 @@ macro_rules! __bitflags_expr_safe_attrs {
         expr: { $e:expr },
             attrs: {
             unprocessed: [
-                // cfg matched here
+                // flag_name matched here
                 #[flag_name $($args:tt)*]
                 $($attrs_rest:tt)*
             ],
@@ -1012,7 +1012,7 @@ macro_rules! __bitflags_item_safe_attrs {
         item: { $i:item },
             attrs: {
             unprocessed: [
-                // cfg matched here
+                // flag_name matched here
                 #[flag_name $($args:tt)*]
                 $($attrs_rest:tt)*
             ],
@@ -1032,7 +1032,7 @@ macro_rules! __bitflags_item_safe_attrs {
         }
     };
     // Process the next attribute on the current flag
-    // `$other`: The next flag should not be propagated to items
+    // `$other`: The next flag should be propagated
     (
         item: { $i:item },
             attrs: {

--- a/src/public.rs
+++ b/src/public.rs
@@ -197,7 +197,7 @@ macro_rules! __impl_public_bitflags {
                                 $crate::__bitflags_expr_safe_attrs!(
                                     $(#[$inner $($args)*])*
                                     {
-                                        if name == $crate::__private::core::stringify!($Flag) {
+                                        if name == $crate::__bitflags_flag_name!($(#[$inner $($args)*])* { $Flag }) {
                                             return $crate::__private::core::option::Option::Some(Self($PublicBitFlags::$Flag.bits()));
                                         }
                                     }
@@ -520,12 +520,16 @@ macro_rules! __impl_public_bitflags_consts {
                 $crate::__bitflags_flag!({
                     name: $Flag,
                     named: {
-                        $(#[$inner $($args)*])*
-                        #[allow(
-                            deprecated,
-                            non_upper_case_globals,
-                        )]
-                        pub const $Flag: Self = Self::from_bits_retain($value);
+                        $crate::__bitflags_item_safe_attrs!(
+                            $(#[$inner $($args)*])*
+                            #[allow(
+                                deprecated,
+                                non_upper_case_globals,
+                            )]
+                            {
+                                pub const $Flag: Self = Self::from_bits_retain($value);
+                            }
+                        );
                     },
                     unnamed: {},
                 });
@@ -546,7 +550,7 @@ macro_rules! __impl_public_bitflags_consts {
                                         deprecated,
                                         non_upper_case_globals,
                                     )]
-                                    $crate::Flag::new($crate::__private::core::stringify!($Flag), $PublicBitFlags::$Flag)
+                                    $crate::Flag::new($crate::__bitflags_flag_name!($(#[$inner $($args)*])* { $Flag }), $PublicBitFlags::$Flag)
                                 }
                             )
                         },

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -134,4 +134,11 @@ bitflags! {
         /// External
         const _ = !0;
     }
+
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+    pub struct TestRenamed: u8 {
+        /// 1
+        #[flag_name = "custom"]
+        const A = 1;
+    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,6 +8,7 @@ mod difference;
 mod empty;
 mod eq;
 mod extend;
+mod flag_name;
 mod flags;
 mod fmt;
 mod from_bits;
@@ -140,5 +141,14 @@ bitflags! {
         /// 1
         #[flag_name = "custom"]
         const A = 1;
+        /// 1 << 1
+        #[flag_name = "custom"]
+        const B = 1 << 1;
+        /// 1 << 2
+        #[flag_name = "c"]
+        const C = 1 << 2;
+        /// 1 << 3
+        #[flag_name = "custom | e"]
+        const D = 1 << 3;
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -140,6 +140,7 @@ bitflags! {
     pub struct TestRenamed: u8 {
         /// 1
         #[flag_name = "custom"]
+        #[flag_name = "a"]
         const A = 1;
         /// 1 << 1
         #[flag_name = "custom"]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -30,6 +30,10 @@ mod union;
 mod unknown;
 mod unknown_bits;
 
+mod custom {
+    pub const NAME: &'static str = "custom";
+}
+
 bitflags! {
     #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
     pub struct TestFlags: u8 {
@@ -139,7 +143,7 @@ bitflags! {
     #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
     pub struct TestRenamed: u8 {
         /// 1
-        #[flag_name = "custom"]
+        #[flag_name = custom::NAME]
         #[flag_name = "a"]
         const A = 1;
         /// 1 << 1

--- a/src/tests/flag_name.rs
+++ b/src/tests/flag_name.rs
@@ -1,0 +1,40 @@
+use super::*;
+
+use crate::{parser::*, Flags};
+
+#[test]
+fn cases() {
+    let flags = TestRenamed::FLAGS
+        .iter()
+        .map(|flag| (flag.name(), flag.value().bits()))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        vec![
+            ("custom", 1),
+            ("custom", 1 << 1),
+            ("c", 1 << 2),
+            ("custom | e", 1 << 3),
+        ],
+        flags,
+    );
+
+    // Original names are not recognized
+    assert!(TestRenamed::from_name("A").is_none());
+
+    // Regular renames are recognized
+    assert_eq!(TestRenamed::C, TestRenamed::from_name("c").unwrap());
+
+    // The first duplicate name is recognized
+    assert_eq!(TestRenamed::A, TestRenamed::from_name("custom").unwrap());
+
+    // Exotic names are recognized
+    assert_eq!(
+        TestRenamed::D,
+        TestRenamed::from_name("custom | e").unwrap()
+    );
+
+    // The parser doesn't have defined behavior on exotic names, but we
+    // make sure it does _something_
+    assert!(from_str_truncate::<TestRenamed>("custom | e").is_err());
+}

--- a/tests/compile-fail/bitflags_flag_name_empty.rs
+++ b/tests/compile-fail/bitflags_flag_name_empty.rs
@@ -1,0 +1,10 @@
+use bitflags::bitflags;
+
+bitflags! {
+    pub struct Flags1: u32 {
+        #[flag_name]
+        const FLAG_A = 0b00000001;
+    }
+}
+
+fn main() {}

--- a/tests/compile-fail/bitflags_flag_name_empty.stderr
+++ b/tests/compile-fail/bitflags_flag_name_empty.stderr
@@ -1,0 +1,5 @@
+error: cannot find attribute `flag_name` in this scope
+ --> tests/compile-fail/bitflags_flag_name_empty.rs:5:11
+  |
+5 |         #[flag_name]
+  |           ^^^^^^^^^

--- a/tests/compile-fail/bitflags_flag_name_non_str.rs
+++ b/tests/compile-fail/bitflags_flag_name_non_str.rs
@@ -1,0 +1,10 @@
+use bitflags::bitflags;
+
+bitflags! {
+    pub struct Flags1: u32 {
+        #[flag_name = 42]
+        const FLAG_A = 0b00000001;
+    }
+}
+
+fn main() {}

--- a/tests/compile-fail/bitflags_flag_name_non_str.stderr
+++ b/tests/compile-fail/bitflags_flag_name_non_str.stderr
@@ -1,0 +1,44 @@
+error[E0308]: mismatched types
+ --> tests/compile-fail/bitflags_flag_name_non_str.rs:5:23
+  |
+3 | / bitflags! {
+4 | |     pub struct Flags1: u32 {
+5 | |         #[flag_name = 42]
+  | |                       ^^ expected `&str`, found integer
+6 | |         const FLAG_A = 0b00000001;
+7 | |     }
+8 | | }
+  | |_- arguments to this function are incorrect
+  |
+note: associated function defined here
+ --> src/traits.rs
+  |
+  |     pub const fn new(name: &'static str, value: B) -> Self {
+  |                  ^^^
+
+error[E0277]: can't compare `&str` with `{integer}`
+ --> tests/compile-fail/bitflags_flag_name_non_str.rs:3:1
+  |
+3 | / bitflags! {
+4 | |     pub struct Flags1: u32 {
+5 | |         #[flag_name = 42]
+  | |                       --
+6 | |         const FLAG_A = 0b00000001;
+7 | |     }
+8 | | }
+  | | ^ no implementation for `&str == {integer}`
+  | |_|
+  |
+  |
+  = help: the trait `PartialEq<{integer}>` is not implemented for `&str`
+  = help: the following other types implement trait `PartialEq<Rhs>`:
+            `&str` implements `PartialEq<ByteStr>`
+            `&str` implements `PartialEq<ByteString>`
+            `&str` implements `PartialEq<Cow<'_, str>>`
+            `&str` implements `PartialEq<OsString>`
+            `&str` implements `PartialEq<String>`
+            `str` implements `PartialEq<ByteStr>`
+            `str` implements `PartialEq<ByteString>`
+            `str` implements `PartialEq<Cow<'_, str>>`
+          and $N others
+  = note: this error originates in the macro `$crate::__impl_public_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-pass/bitflags_flag_name.rs
+++ b/tests/compile-pass/bitflags_flag_name.rs
@@ -1,0 +1,14 @@
+extern crate bitflags;
+
+bitflags::bitflags! {
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct Example: u64 {
+        #[flag_name = "custom"]
+        const FLAG = 0b01;
+    }
+}
+
+fn main() {
+    assert_eq!(Example::FLAG, Example::from_name("custom").unwrap());
+    assert_eq!("custom", Example::FLAG.iter_names().next().unwrap().0);
+}


### PR DESCRIPTION
Closes #470 

This PR introduces a `#[flag_name]` attribute you can apply to flags to give them a different name. I've tried to avoid adding these kinds of attributes in the past, but there's no way to get around this one with `bitflags`, so we support it. It lets you write:

```rust
bitflags! {
    pub struct MyFlags: u8 {
        #[flag_name = "a"]
        const A = 1;
    }
}
```

There isn't any validation done on the `flag_name` given, so you could pick strange names like `_`, or `a | b` or `  a`, etc. I need to add some more test coverage before this is ready.