### PR TITLE
Flags: adjust order of elements in manual implementation example

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -88,19 +88,19 @@ use bitflags::{Flag, Flags};
 struct MyFlags(u8);
 
 impl Flags for MyFlags {
+    type Bits = u8;
+
     const FLAGS: &'static [Flag<Self>] = &[
         Flag::new("A", MyFlags(1)),
         Flag::new("B", MyFlags(1 << 1)),
     ];
 
-    type Bits = u8;
+    fn bits(&self) -> Self::Bits {
+        self.0
+    }
 
     fn from_bits_retain(bits: Self::Bits) -> Self {
         MyFlags(bits)
-    }
-
-    fn bits(&self) -> Self::Bits {
-        self.0
     }
 }
 ```


### PR DESCRIPTION
Match the order given in the trait definition so that it is easier to compare the example with the requirements.